### PR TITLE
Require manual confirmation to start a deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,21 @@ There are a few main playbooks provided in this repository:
 - `post_install.yml`: fetches the `kubeconfig` for the deployed cluster and places it on the bastion host.
 - `site.yml` simply runs all three in order.
 
-Each of the playbooks requires only an inventory, and can be run like this:
+Each of the playbooks requires an inventory and an inventory vault file, and can be run like this:
 
 ```bash
 ansible-playbook -i inventory site.yml -e "@inventory.vault.yml" --ask-vault-pass
+```
+
+When performing a full deployment, Crucible may first present you with a deployment plan containing all the key configuration details. Please review the deployment plan carefully to ensure that the right inventory file has been provided. To confirm the plan and proceed with the deployment, type `yes` when prompted.
+
+In order to skip interactive prompts in environments where user input cannot be given, extend the command with the `-e skip_interactive_prompts=true` option.  
+If this option is enabled, the generation of a deployment plan is omitted, and the deployment process starts immediately after the command is run.
+
+```bash
+# Careful: this command will start the deployment right away, and will not ask for manual confirmation.
+ansible-playbook -i inventory site.yml -e "@inventory.vault.yml" --ask-vault-pass \
+  -e skip_interactive_prompts=true
 ```
 
 ## Prerequisite Services

--- a/playbooks/display_deployment_plan.yml
+++ b/playbooks/display_deployment_plan.yml
@@ -1,0 +1,7 @@
+---
+- name: Display deployment plan
+  hosts: localhost
+  gather_facts: false
+
+  roles:
+    - display_deployment_plan

--- a/roles/display_deployment_plan/tasks/main.yml
+++ b/roles/display_deployment_plan/tasks/main.yml
@@ -1,0 +1,88 @@
+---
+- name: Display deployment plan if interactive prompts are allowed
+  when: not ((skip_interactive_prompts | default(false)) | bool)
+  block:
+    - name: Display inventory details and ask for user confirmation
+      pause:
+        prompt: |-
+          An OpenShift cluster is about to be deployed. Please double check the provided inventory details.
+
+          * General configuration
+
+            {{ row_format_str | format('Cluster name', inventory.cluster_name) }}
+            {{ row_format_str | format('Base DNS domain', inventory.base_dns_domain) }}
+
+            {{ row_format_str | format('API Virtual IP', inventory.api_vip) }}
+            {{ row_format_str | format('Ingress Virtual IP', inventory.ingress_vip) }}
+
+            {{ row_format_str | format('OpenShift version', inventory.openshift_full_version) }}
+
+          * Prerequisite services configuration
+
+            {{ row_format_str | format('Setup NTP Service', inventory.setup_ntp_service) }}
+            {{ row_format_str | format('Setup DNS Service', inventory.setup_dns_service) }}
+            {{ row_format_str | format('Setup Registry Service', inventory.setup_registry_service) }}
+            {{ row_format_str | format('Setup HTTP Store Service', inventory.setup_http_store_service) }}
+
+          * Groups and hosts configuration
+
+          {% for group_name in inventory.groups_filtered %}
+            {{ group_name }}:
+            {% for host_name in groups[group_name] %}
+            {{ hosts_row_format_str | format(host_name, (hostvars[host_name]['ansible_host'] | default(messages.value_missing))) }}
+            {% else %}
+            {{ messages.hosts_missing }}
+            {% endfor %}
+
+          {% else %}
+            {{ messages.groups_missing }}
+
+          {% endfor -%}
+          ---
+
+          Are you sure you want to proceed with the deployment using this inventory configuration?
+
+          Enter a value [yes/NO]
+      vars:
+        # Every row consists of two columns. To ensure all items in the right column are aligned,
+        # a minimum width of the left column is set in the following variable.
+        left_column_width: 26
+        row_format_str: '%-{{ left_column_width }}s %s'
+        # To improve readability, all hosts listed in the "Groups and hosts configuration" section
+        # are nested under groups by the number of spaces defined in the variable below.
+        # For padding set to 2, the displayed output is as follows:
+        # group_name:
+        #   host_name_A
+        #   host_name_B
+        hosts_row_padding: 2
+        hosts_row_format_str: '%-{{ (left_column_width - hosts_row_padding) }}s %s'
+        # In the sample inventory, some host groups are nested under other groups.
+        # To prevent the defined hosts from being displayed multiple times, selected top level
+        # groups are omitted from the deployment plan.
+        groups_to_exclude: ['all', 'nodes', 'ungrouped']
+        messages:
+          value_missing: "<not set>"
+          hosts_missing: "<no hosts set>"
+          groups_missing: "<no groups set>"
+        # A default error message is assigned to each variable referenced in the deployment plan.
+        # This prevents the prompt from not being displayed due to templating errors if a valid
+        # inventory file is not provided.
+        inventory:
+          cluster_name: "{{ cluster_name | default(messages.value_missing) }}"
+          base_dns_domain: "{{ base_dns_domain | default(messages.value_missing) }}"
+          api_vip: "{{ api_vip | default(messages.value_missing) }}"
+          ingress_vip: "{{ ingress_vip | default(messages.value_missing) }}"
+          openshift_full_version: "{{ openshift_full_version | default(messages.value_missing) }}"
+          setup_ntp_service: "{{ setup_ntp_service | default(messages.value_missing) }}"
+          setup_dns_service: "{{ setup_dns_service | default(messages.value_missing) }}"
+          setup_registry_service: "{{ setup_registry_service | default(messages.value_missing) }}"
+          setup_http_store_service: "{{ setup_http_store_service | default(messages.value_missing) }}"
+          groups_filtered: "{{ groups | difference(groups_to_exclude) }}"
+      register: display_deployment_plan__confirmation
+
+    - name: Assert the deployment plan is confirmed
+      assert:
+        that:
+          - (display_deployment_plan__confirmation.user_input | lower | trim) in ['y', 'yes']
+        fail_msg: "The deployment plan must be confirmed by the user"
+        quiet: true

--- a/site.yml
+++ b/site.yml
@@ -1,4 +1,6 @@
 ---
+- import_playbook: playbooks/display_deployment_plan.yml
+
 - import_playbook: deploy_prerequisites.yml
 
 - import_playbook: deploy_cluster.yml


### PR DESCRIPTION
Executing the site.yml playbook will first present the user with a deployment plan, listing all the key configuration details fetched from the inventory file. This is to ensure that the user has provided the correct inventory file for deployment. Through an interactive prompt, the user can decide whether to confirm the generated deployment plan.

The interactive prompt can be disabled using a dedicated variable. This variable should be used to manage all interactive prompts initiated by Crucible that may require user input.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>

A deployment plan for the sample inventory is listed below. 

```
[display_deployment_plan : Display inventory details and ask for user confirmation]
An OpenShift cluster is about to be deployed. Please double check the provided inventory details.

* General configuration

  Cluster name               clustername
  Base DNS domain            example.lab

  API Virtual IP             10.60.0.96
  Ingress Virtual IP         10.60.0.97

  OpenShift version          4.6.16

* Prerequisite services configuration

  Setup NTP Service          False
  Setup DNS Service          False
  Setup Registry Service     False
  Setup HTTP Store Service   True

* Groups and hosts configuration

  bastions:
    bastion                  172.28.11.51
  
  services:
    assisted_installer       service_host.example.lab
    registry_host            registry.example.lab
    dns_host                 10.40.0.100
    http_store               10.40.0.100
    ntp_host                 10.40.0.100
    vm_host                  vm_host.clustername.example.lab
  
  masters:
    super1                   10.60.0.101
    super2                   10.60.0.102
    super3                   10.60.0.103
  
  workers:
    worker1                  10.60.0.104
    worker2                  10.60.0.105
  
---

Are you sure you want to proceed with the deployment using this inventory configuration?

Enter a value [yes/NO]:
```