### PR TITLE
Reboots the node rather than the ILO

### DIFF
--- a/roles/boot_disk/tasks/hpe.yml
+++ b/roles/boot_disk/tasks/hpe.yml
@@ -38,8 +38,8 @@
 
 - name: HPE Restart system power gracefully
   community.general.redfish_command:
-    category: Manager
-    command: PowerGracefulRestart
+    category: Systems
+    command: ForceRestart
     baseuri: "{{ hostvars[item]['bmc_address'] }}"
     username: "{{ hostvars[item]['bmc_user'] }}"
     password: "{{ hostvars[item]['bmc_password'] }}"


### PR DESCRIPTION
The final boot disk task incorrectly set the ILO/Manager interface
to reboot rather than the node iteself. This commit fixes that.