### PR TITLE
Fix Day 2 worker node network config

### DIFF
--- a/roles/generate_discovery_iso/tasks/main.yml
+++ b/roles/generate_discovery_iso/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: static IP addresses
   include_tasks: static.yml
   when: hostvars[item].network_config is defined
-  loop: "{{ groups['masters'] + ( groups['workers'] | default([]) ) }}"
+  loop: "{{ groups['nodes'] | default([])}}"
 
 - name: IP config
   set_fact:


### PR DESCRIPTION
day2_workers weren't included in their network config task. This
commmit fixes this.