### PR TITLE
Stops all nodes from being re-provisioned when scaling out

### DIFF
--- a/deploy_day2_workers.yml
+++ b/deploy_day2_workers.yml
@@ -12,6 +12,7 @@
   vars:
     discovery_iso_name: "{{ day2_discovery_iso_name }}"
     boot_iso_url: "{{ discovery_iso_server }}/{{ day2_discovery_iso_name }}"
+    boot_iso_hosts: day2_workers
 
 - import_playbook: playbooks/add_day2_nodes.yml
 


### PR DESCRIPTION
Currently the playbook to add day2 workers doesn't have a var to
specify boot_iso_hosts so all hosts are rebooted and
re-provisioned which destroys the cluster. This commit fixes this.

Fixes #17