### PR TITLE
Fix HPE reboot correctly

### DIFF
--- a/roles/boot_disk/tasks/hpe.yml
+++ b/roles/boot_disk/tasks/hpe.yml
@@ -35,11 +35,18 @@
     validate_certs: no
     return_content: yes
 
-
-- name: HPE Restart system power gracefully
-  community.general.redfish_command:
-    category: Systems
-    command: ForceRestart
-    baseuri: "{{ hostvars[item]['bmc_address'] }}"
-    username: "{{ hostvars[item]['bmc_user'] }}"
+# ILO appears to use a custom url for Reset so we cannot use the redfish module here
+- name: HPE Restart system power forcefully
+  uri:
+    url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Systems/1/Actions/ComputerSystem.Reset"
+    user: "{{ hostvars[item]['bmc_user'] }}"
     password: "{{ hostvars[item]['bmc_password'] }}"
+    method: POST
+    headers:
+      content-type: application/json
+      Accept: application/json
+    body: '{"ResetType": "ForceRestart"}'
+    body_format: json
+    force_basic_auth: yes
+    validate_certs: no
+    return_content: yes


### PR DESCRIPTION
Sigh. ILO doesn't use the same path every other vendor does so
we need to switch to the uri module. Tested and verified.