### PR TITLE
Allow multiple DNS servers IPs.

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -104,7 +104,9 @@ network_config:
         ipv4:
           - ip: "{{ ansible_host}}"
             prefix: "{{ mask }}"
-  dns_server_ip: "{{dns}}" # optional
+  dns_server_ips: 
+    - "{{ dns }}" 
+    - "{{ dns2 }}"
   routes: # optional
     - destination: 0.0.0.0/0
       address: "{{ gateway }}"
@@ -114,7 +116,7 @@ network_config:
 where the variables are as follows:
 
 - `ip`: The static IP is set
-- `dns`: IP of the DNS server
+- `dns` & `dns2`: IPs of the DNS servers
 - `gateway`: IP of the gateway
 - `mask`: Length of subnet mask (e.g. 24)
 - `interface`: The name of the interface you wish to configure

--- a/roles/generate_discovery_iso/templates/nmstate.yml.j2
+++ b/roles/generate_discovery_iso/templates/nmstate.yml.j2
@@ -1,9 +1,11 @@
 #jinja2:trim_blocks: True, lstrip_blocks: True
-{% if network_config.dns_server_ip is defined %}
+{% if network_config.dns_server_ips is defined %}
 dns-resolver:
   config:
     server:
-    - {{ network_config.dns_server_ip  }}
+    {% for ip in network_config.dns_server_ips  %}
+    - {{ ip }}
+    {% endfor %}
 {% endif %}
 interfaces:
 {% for interface in network_config.interfaces %}


### PR DESCRIPTION
Currently only one DNS server could be configured.
Based on the nmstate exaple docs: https://nmstate.io/kubernetes-nmstate/examples.html#dns