### PR TITLE
later versions of skopeo (Fedora) reject the command if the --authfil…

### DIFF
--- a/roles/get_image_hash/tasks/get_image_hash.yml
+++ b/roles/get_image_hash/tasks/get_image_hash.yml
@@ -1,5 +1,5 @@
 - name: "Get {{ item.key }} image hash"
-  shell: "skopeo --authfile {{ local_pull_secret_path }} inspect docker://{{ item.value.image }}:{{ item.value.tag }}"
+  shell: "skopeo inspect --authfile {{ local_pull_secret_path }} docker://{{ item.value.image }}:{{ item.value.tag }}"
   register: result
   changed_when: false
 


### PR DESCRIPTION
…e flag is passed before "inspect".  The "skopeo inspect --authfile" format works with both newer and older versions of skopeo