### PR TITLE
Add tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .DS_Store
 *.txt
-*.pub
 !requirements.txt
+!test-requirements.txt
+!bindep.txt
+*.pub
 __stuff/**
 .history/
 .vscode

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Requires the following to be installed on the deployment host:
 dnf install ansible python3-netaddr skopeo
 ```
 
+You can also just use the output from bindep
+
+```bash
+dnf install $(bindep -b bindep.txt)
+```
+
 There's also some required Ansible modules that can be installed with the following command:
 
 ```bash
@@ -64,15 +70,15 @@ ansible-galaxy collection install -r requirements.yml
 
 ### Inventory Vault File Management
 
-The inventory vault files should be encrypted and protected at all times, as they may contain secret values and sensitive information. 
+The inventory vault files should be encrypted and protected at all times, as they may contain secret values and sensitive information.
 
 To encrypt a vault file named `inventory.vault.yml`, issue the following command.
 
 ```bash
-ansible-vault encrypt inventory.vault.yml 
+ansible-vault encrypt inventory.vault.yml
 ```
 
-An encrypted vault file can be referenced when executing the playbooks with the `ansible-playbook` command.  
+An encrypted vault file can be referenced when executing the playbooks with the `ansible-playbook` command.
 To that end, provide the option `-e "@{PATH_TO_THE_VAULT_FILE}"`.
 
 To allow Ansible to read values from an encrypted vault file, a password for decrypting the vault must be provided. Provide the `--ask-vault-pass` flag to force Ansible to ask for a password to the vault before the selected playbook is executed.
@@ -116,7 +122,7 @@ ansible-playbook -i inventory site.yml -e "@inventory.vault.yml" --ask-vault-pas
 
 When performing a full deployment, Crucible may first present you with a deployment plan containing all the key configuration details. Please review the deployment plan carefully to ensure that the right inventory file has been provided. To confirm the plan and proceed with the deployment, type `yes` when prompted.
 
-In order to skip interactive prompts in environments where user input cannot be given, extend the command with the `-e skip_interactive_prompts=true` option.  
+In order to skip interactive prompts in environments where user input cannot be given, extend the command with the `-e skip_interactive_prompts=true` option.
 If this option is enabled, the generation of a deployment plan is omitted, and the deployment process starts immediately after the command is run.
 
 ```bash
@@ -189,6 +195,19 @@ Existing tests can be run using
 
 ```bash
 ansible-playbook tests/run_tests.yml
+```
+
+You can rely on the existing tox environment, which would collect and install
+the dependencies, create a virtualenvironment and  run the test just by using
+
+```bash
+tox -etests
+```
+
+You can also trigger a set of linters in a different tox environment
+
+```bash
+tox -elinters
 ```
 
 ## Related Documentation

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,2 @@
+# Skopeo
+skopeo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-netaddr==0.8.0
+netaddr==0.8.0 # BSD
+ansible>=4.0.0 # GNU v3.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+ansible-lint==5.0.10 # MIT
+bindep>=2.10.1 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,43 @@
+[tox]
+minversion = 3.18.0
+skipsdist = True
+envlist = linters,tests
+
+[testenv]
+passenv = *
+skip_install = true
+setenv = VIRTUAL_ENV={envdir]
+         ANSIBLE_CONFIG={toxinidir}/ansible.cfg
+         ANSIBLE_NOCOWS=1
+         ANSIBLE_RETRY_FILES_ENABLED=0
+         ANSIBLE_STDOUT_CALLBACK=debug
+         ANSIBLE_LOG_PATH={envlogdir}/ansible.log
+         ANSIBLE_PYTHON_INTERPRETER={envdir}/bin/python
+         ANSIBLE_COLLECTIONS_PATHS={envdir}/collections
+install_command = pip install {opts} {packages}
+deps =
+    -r {toxinidir}/requirements.txt
+    -r {toxinidir}/test-requirements.txt
+whitelist_externals =
+  bash
+  tox
+  ansible-galaxy
+commands =
+     ansible-galaxy install -fr {toxinidir}/requirements.yml
+
+[testenv:bindep]
+deps = bindep
+commands = bindep test
+
+[testenv:venv]
+basepython = python3
+commands = {[testenv]commands}
+           {[testenv:bindep]commands}
+
+[testenv:linters]
+commands = {[testenv]commands}
+           bash -c "ansible-lint {toxinidir}/playbooks/roles/"
+
+[testenv:tests]
+commands = {[testenv]commands}
+           ansible-playbook tests/run_tests.yml


### PR DESCRIPTION
This PR adds tox and bindep support.

It allows to automate the creation of virtualenvironments with all the
project's dependencies, as well as triggering tess in a more automated
way.

It also sets the ansible version to be used, as it not being tracked may
lead to unexpected issues.

Examples of usage have also been added to the README file.