### PR TITLE
update ansible-lint action

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,76 +1,33 @@
-name: Ansible Lint  # feel free to pick your own name
+name: Ansible Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: 
+      - main
+  pull_request:
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
-
-
     steps:
-    # Important: This sets up your GITHUB_WORKSPACE environment variable
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: actions/cache@v2.1.6
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
 
-    - uses: actions/setup-python@v2.2.2
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt') }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
+      - name: Install required dependencies
+        run: |
+          pip install ansible-lint ansible==2.9
+          pip install -r requirements.txt
 
-
-    - name: Lint Ansible Playbook
-      # replace "master" with any valid ref
-      uses: ansible/ansible-lint-action@master
-      with:
-        # [required]
-        # Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
-        # or valid Ansible directories according to the Ansible role
-        # directory structure.
-        # If you want to lint multiple ansible files, use the following syntax
-        # targets: |
-        #   playbook_1.yml
-        #   playbook_2.yml
-        targets: |
-          boot_iso.yml
-          deploy_cluster.yml
-          generate_rwn_iso.yml
-          install_cluster.yml
-
-        # [optional]
-        # Arguments to override a package and its version to be set explicitly.
-        # Must follow the example syntax.
-
-        # [optional]
-        # Arguments to be passed to the ansible-lint
-
-        # Options:
-        #   -q                    quieter, although not silent output
-        #   -p                    parseable output in the format of pep8
-        #   --parseable-severity  parseable output including severity of rule
-        #   -r RULESDIR           specify one or more rules directories using one or
-        #                         more -r arguments. Any -r flags override the default
-        #                         rules in ansiblelint/rules, unless -R is also used.
-        #   -R                    Use default rules in ansiblelint/rules in addition to
-        #                         any extra
-        #                         rules directories specified with -r. There is no need
-        #                         to specify this if no -r flags are used
-        #   -t TAGS               only check rules whose id/tags match these values
-        #   -x SKIP_LIST          only check rules whose id/tags do not match these
-        #                         values
-        #   --nocolor             disable colored output
-        #   --exclude=EXCLUDE_PATHS
-        #                         path to directories or files to skip. This option is
-        #                         repeatable.
-        #   -c C                  Specify configuration file to use. Defaults to ".ansible-lint"
-        args: ""
+      - name: Run ansible Lint
+        run: |
+          ansible-lint --exclude .github/ -v

--- a/.github/workflows/crucible-tests.yml
+++ b/.github/workflows/crucible-tests.yml
@@ -10,6 +10,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt') }}
+
       - name: Install required dependencies
         run: |
           pip install ansible


### PR DESCRIPTION
The official ansible-lint action disregards the .ansible-lint file

This runs the ansible linter from scratch, and also uses caching
to speed up execution.

Signed-off-by: Charlie Wheeler-Robinson <cwheeler@redhat.com>