### PR TITLE
Updating chrony.conf

### DIFF
--- a/roles/setup_ntp/defaults/main.yml
+++ b/roles/setup_ntp/defaults/main.yml
@@ -4,3 +4,5 @@ ntp_pool_servers:
   - 1.us.pool.ntp.org
   - 2.us.pool.ntp.org
   - 3.us.pool.ntp.org
+
+enable_logging: false

--- a/roles/setup_ntp/templates/chrony.conf.j2
+++ b/roles/setup_ntp/templates/chrony.conf.j2
@@ -1,20 +1,23 @@
 # {{ ansible_managed }}
-stratumweight 0
 driftfile /var/lib/chrony/drift
-rtcsync
-makestep 10 3
+bindcmdaddress {{ ntp_server }}
 bindcmdaddress 127.0.0.1
 bindcmdaddress ::1
 keyfile /etc/chrony.keys
-noclientlog
-logchange 0.5
-logdir /var/log/chrony
-manual
 local stratum 10
+rtcsync
+makestep 1.0 3
+manual
+{% if enable_logging %}
+logdir /var/log/chrony
+log measurements statistics tracking
+{% end if %}
+allow 127.0.0.1
 {% if ntp_server_allow %}
 allow {{ ntp_server_allow }}
 {% endif %}
+server 127.0.0.1
 {% for item in ntp_pool_servers %}
-Server {{ item }}
+server {{ item }}
 {% endfor %}
 


### PR DESCRIPTION
Made changes to the chrony.conf template to allow crucible to:

- set the listening address to `{{ ntp_server }}`.
- set a default listen address of 127.0.0.1
- allow from 127.0.0.1
- Cleaned up chrony.conf file
- Enables logging on the server.