### PR TITLE
Release image digest and assisted installer versions config.

### DIFF
--- a/roles/get_image_hash/defaults/main.yml
+++ b/roles/get_image_hash/defaults/main.yml
@@ -3,19 +3,28 @@ controller_tag: "{{ ai_version }}"
 installer_agent_tag: "{{ ai_version }}"
 installer_tag: "{{ ai_version }}"
 
-images_to_get_hash_for:
-  release:
-    image: quay.io/openshift-release-dev/ocp-release
-    tag: "{{ release_tag | default(openshift_full_version + '-x86_64') }}"
+ocp_release_versions_map:
+  '4.6': 4.6.16
+  '4.7': 4.7.33
+  '4.8': 4.8.14
+  '4.9': 4.9.0
+
+get_release_images: true
+
+release_image_url: "quay.io/openshift-release-dev/ocp-release"
+
+non_release_images:
   controller:
-    image: quay.io/ocpmetal/assisted-installer-controller
-    tag: "{{ controller_tag }}"
+      image: quay.io/ocpmetal/assisted-installer-controller
+      tag: "{{ controller_tag }}"
   installer_agent:
     image: quay.io/ocpmetal/assisted-installer-agent
     tag: "{{ installer_agent_tag }}"
   installer:
     image: quay.io/ocpmetal/assisted-installer
     tag: "{{ installer_tag }}"
+
+images_to_get_hash_for: "{{ non_release_images | combine(release_images | default({})) }}"
 
 destination_hosts:
   - registry_host

--- a/roles/get_image_hash/defaults/main.yml
+++ b/roles/get_image_hash/defaults/main.yml
@@ -3,20 +3,23 @@ controller_tag: "{{ ai_version }}"
 installer_agent_tag: "{{ ai_version }}"
 installer_tag: "{{ ai_version }}"
 
-ocp_release_versions_map:
+ocp_release_versions_map_all:
   '4.6': 4.6.16
   '4.7': 4.7.33
   '4.8': 4.8.14
   '4.9': 4.9.0
 
 get_release_images: true
+get_all_release_versions: false
+
+ocp_release_versions_map: "{{ get_all_release_versions | ternary(ocp_release_versions_map_all, {openshift_version: ocp_release_versions_map_all[openshift_version]}) }}"
 
 release_image_url: "quay.io/openshift-release-dev/ocp-release"
 
-non_release_images:
+assisted_installer_images:
   controller:
-      image: quay.io/ocpmetal/assisted-installer-controller
-      tag: "{{ controller_tag }}"
+    image: quay.io/ocpmetal/assisted-installer-controller
+    tag: "{{ controller_tag }}"
   installer_agent:
     image: quay.io/ocpmetal/assisted-installer-agent
     tag: "{{ installer_agent_tag }}"
@@ -24,7 +27,7 @@ non_release_images:
     image: quay.io/ocpmetal/assisted-installer
     tag: "{{ installer_tag }}"
 
-images_to_get_hash_for: "{{ non_release_images | combine(release_images | default({})) }}"
+images_to_get_hash_for: "{{ assisted_installer_images | combine(release_images | default({})) }}"
 
 destination_hosts:
   - registry_host

--- a/roles/get_image_hash/tasks/main.yml
+++ b/roles/get_image_hash/tasks/main.yml
@@ -29,3 +29,10 @@
   delegate_to: "{{ item }}"
   delegate_facts: true
   loop: "{{ destination_hosts }}"
+
+- name: "Set ocp_release_versions in assisted_installer host"
+  set_fact:
+    ocp_release_versions: "{{ ocp_release_versions_map.keys() | list }}"
+  when: get_release_images | bool
+  delegate_to: "assisted_installer"
+  delegate_facts: true

--- a/roles/get_image_hash/tasks/main.yml
+++ b/roles/get_image_hash/tasks/main.yml
@@ -1,6 +1,20 @@
 - name: check skopeo is installed # noqa no-changed-when
   shell: /usr/bin/skopeo --version
 
+- name: Build release_images entries
+  set_fact:
+    release_images: "{{ release_images | combine(
+        {'release_' + item.short : {
+            'image': release_image_url,
+            'tag': item.long + '-x86_64',
+          }
+        })
+      }}"
+  vars:
+    release_images: {}
+  loop: "{{ ocp_release_versions_map | dict2items(key_name='short', value_name='long') }}"
+  when: get_release_images | bool
+
 - name: Find hash for images
   include_tasks:
     file: get_image_hash.yml

--- a/roles/setup_assisted_installer/defaults/main.yml
+++ b/roles/setup_assisted_installer/defaults/main.yml
@@ -12,7 +12,7 @@ assisted_postgres_image: quay.io/ocpmetal/postgresql-12-centos7
 assisted_service_openshift_versions:
   "4.6":
     display_name: 4.6.16
-    release_image: quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64
+    release_image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_4.6'] }}"
     release_version: 4.6.16
     rhcos_image: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso
     rhcos_rootfs: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img
@@ -20,7 +20,7 @@ assisted_service_openshift_versions:
     support_level: production
   "4.7":
     display_name: 4.7.33
-    release_image: quay.io/openshift-release-dev/ocp-release:4.7.33-x86_64
+    release_image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_4.7'] }}"
     release_version: 4.7.33
     rhcos_image: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-4.7.33-x86_64-live.x86_64.iso
     rhcos_rootfs: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-live-rootfs.x86_64.img
@@ -29,7 +29,7 @@ assisted_service_openshift_versions:
   "4.8":
     default: true
     display_name: 4.8.14
-    release_image: quay.io/openshift-release-dev/ocp-release:4.8.14-x86_64
+    release_image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_4.8'] }}"
     release_version: 4.8.14
     rhcos_image: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso
     rhcos_rootfs: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-live-rootfs.x86_64.img
@@ -37,7 +37,7 @@ assisted_service_openshift_versions:
     support_level: production
   "4.9":
     display_name: 4.9.0
-    release_image: quay.io/openshift-release-dev/ocp-release:4.9.0-x86_64
+    release_image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_4.9'] }}"
     release_version: 4.9.0
     rhcos_image: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso
     rhcos_rootfs: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-live-rootfs.x86_64.img
@@ -46,7 +46,7 @@ assisted_service_openshift_versions:
 
 assisted_installer_images:
   release:
-    image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes.release }}"
+    image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_' + openshift_version] }}"
   controller:
     image: "quay.io/ocpmetal/assisted-installer-controller@{{ image_hashes.controller }}"
   installer_agent:

--- a/roles/setup_assisted_installer/defaults/main.yml
+++ b/roles/setup_assisted_installer/defaults/main.yml
@@ -9,10 +9,10 @@ assisted_service_image: "quay.io/ocpmetal/assisted-service:{{ assisted_service_t
 assisted_service_gui_image: "quay.io/ocpmetal/ocp-metal-ui:{{ assisted_service_gui_tag }}"
 assisted_postgres_image: quay.io/ocpmetal/postgresql-12-centos7
 
-assisted_service_openshift_versions:
+assisted_service_openshift_versions_defaults:
   "4.6":
     display_name: 4.6.16
-    release_image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_4.6'] }}"
+    release_image: "quay.io/openshift-release-dev/ocp-release{{ 'release_4.6' in image_hashes | ternary('@' + image_hashes['release_4.6'], ':4.6.16-x86_64') }}"
     release_version: 4.6.16
     rhcos_image: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso
     rhcos_rootfs: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img
@@ -20,7 +20,7 @@ assisted_service_openshift_versions:
     support_level: production
   "4.7":
     display_name: 4.7.33
-    release_image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_4.7'] }}"
+    release_image: "quay.io/openshift-release-dev/ocp-release{{ 'release_4.7' in image_hashes | ternary('@' + image_hashes['release_4.7'], ':4.7.33-x86_64') }}"
     release_version: 4.7.33
     rhcos_image: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-4.7.33-x86_64-live.x86_64.iso
     rhcos_rootfs: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-live-rootfs.x86_64.img
@@ -29,7 +29,7 @@ assisted_service_openshift_versions:
   "4.8":
     default: true
     display_name: 4.8.14
-    release_image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_4.8'] }}"
+    release_image: "quay.io/openshift-release-dev/ocp-release{{'release_4.8' in image_hashes | ternary('@' + image_hashes['release_4.8'], ':4.8.14-x86_64') }}"
     release_version: 4.8.14
     rhcos_image: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso
     rhcos_rootfs: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-live-rootfs.x86_64.img
@@ -37,7 +37,7 @@ assisted_service_openshift_versions:
     support_level: production
   "4.9":
     display_name: 4.9.0
-    release_image: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_4.9'] }}"
+    release_image: "quay.io/openshift-release-dev/ocp-release{{ 'release_4.9' in image_hashes | ternary('@' + image_hashes['release_4.9'], ':4.9.0-x86_64') }}"
     release_version: 4.9.0
     rhcos_image: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso
     rhcos_rootfs: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-live-rootfs.x86_64.img

--- a/roles/setup_assisted_installer/tasks/main.yml
+++ b/roles/setup_assisted_installer/tasks/main.yml
@@ -7,6 +7,16 @@
         name: podman
         state: present
 
+    - name: "Build assisted_service_openshift_versions ({{ item }})"
+      vars:
+        assisted_service_openshift_versions: {}
+      set_fact:
+        assisted_service_openshift_versions: "{{ assisted_service_openshift_versions | combine({
+              item: assisted_service_openshift_versions_defaults[item]
+            })
+          }}"
+      loop: "{{ ocp_release_versions }}"
+
     - name: Open ports zone internal and public, for firewalld
       firewalld:
         port: "{{ item.1 }}/tcp"


### PR DESCRIPTION
* Fix the issue with release images having tags instead of digests which breaks disconnected installs
* By default only configure assisted installer to deploy the version of openshift which we are trying to deploy.