### PR TITLE
Add NetworkManager reload for dnsmasq

### DIFF
--- a/roles/insert_dns_records/tasks/network-manager.yml
+++ b/roles/insert_dns_records/tasks/network-manager.yml
@@ -17,3 +17,8 @@
     name: NetworkManager
     state: started
     enabled: true
+
+- name: Reload NetworkManager
+  ansible.builtin.service:
+    name: NetworkManager
+    state: reloaded


### PR DESCRIPTION
On some RHEL/CentOS versions, dnsmasq isn't starting by NetworkManager after `systemctl restart NetworkManager` and resolv.conf is empty:
```
$ cat /etc/resolv.conf
# Generated by NetworkManager
```

dnsmasq is starting only after NetworkManager reload `systemctl restart NetworkManager` and adds the correct DNS server to resolv.conf:
```
$ cat /etc/resolv.conf
# Generated by NetworkManager
nameserver 127.0.0.1
```

I faced the issue on RHEL 8.5, [here](https://serverfault.com/questions/1054792/networkmanager-isnt-starting-dnsmasq-on-restart-only-reload) is a reference for the same issue on CentOS 7.9.

Adding reload task to make sure dnsmasq is starting.