### PR TITLE
add openshift-clients to bastion dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,14 @@ Requires the following to be installed on the deployment host:
 - [netaddr](https://github.com/netaddr/netaddr)
 - [skopeo](https://github.com/containers/skopeo)
 - [podman](https://github.com/containers/podman/)
+- [kubectl + oc](https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html)
+
+**Important Note** The `openshift-clients` package is part of the (Red Hat OpenShift Container Platform Subscription
+)[https://access.redhat.com/downloads/content/290/]. The repo [must be activated on the bastion host](https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli-rpm_cli-developer-commands) before the dependency installation. It is used for the post-installation cluster validation steps.
+
 
 ```bash
-dnf install ansible python3-netaddr skopeo podman
+dnf install ansible python3-netaddr skopeo podman openshift-clients
 ```
 
 There's also some required Ansible modules that can be installed with the following command:


### PR DESCRIPTION
It is not possible to cleanly install `kubectl` and `oc` on the bastion host given our current constraint of not requiring root on the bastion. In lieu of that, this add documentation of the requirement for them.

For an incomplete example of automating the install on the bastion, see https://github.com/redhat-partner-solutions/crucible/pull/58 which removes the `tar` install and therefore risks missing dependencies.

Signed-off-by: Charlie Wheeler-Robinson <cwheeler@redhat.com>