### PR TITLE
Fix day2 worker node static ip addressing

### DIFF
--- a/roles/generate_discovery_iso/tasks/main.yml
+++ b/roles/generate_discovery_iso/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: static IP addresses
   include_tasks: static.yml
   when: hostvars[item].network_config is defined
-  loop: "{{ groups['masters'] + ( groups['workers'] | default([]) ) }}"
+  loop: "{{ groups['nodes'] | default([])}}"
 
 - name: IP config
   set_fact:


### PR DESCRIPTION
When provisioning day2 worker nodes with static ip addresses, the
day2_worker group is not currently processed meaning these nodes
do not get an IP address. This commit fixes this.