### PR TITLE
Fixes day2 worker playbook for disconnected installs

### DIFF
--- a/playbooks/create_day2_cluster.yml
+++ b/playbooks/create_day2_cluster.yml
@@ -2,3 +2,5 @@
   roles:
     - role: create_day2_cluster
       when: groups['day2_workers'] | default([]) | length > 0
+  vars:
+    - disconnected: "{{ use_local_mirror_registry | default(setup_registry_service | default(true)) }}"

--- a/roles/create_day2_cluster/defaults/main.yml
+++ b/roles/create_day2_cluster/defaults/main.yml
@@ -2,6 +2,11 @@
 # defaults file for create_day2_cluster
 
 secure: false
+disconnected: False
+manifests: True
+
+mirror_registry: "{{ hostvars['registry_host']['registry_fqdn'] }}:{{ hostvars['registry_host']['registry_port'] }}"
+
 
 ASSISTED_INSTALLER_HOST: "{{ hostvars['assisted_installer']['host'] }}"
 ASSISTED_INSTALLER_PORT: "{{ hostvars['assisted_installer']['port'] }}"
@@ -14,3 +19,7 @@ NO_PROXY: ""
 # HTTP Basic Authentication
 HTTP_AUTH_USERNAME: "none"
 HTTP_AUTH_PASSWORD: "none"
+
+manifest_templates:
+  - 50-worker-nm-fix-ipv6.yml
+  - 50-worker-remove-ipi-leftovers.yml

--- a/roles/create_day2_cluster/tasks/main.yml
+++ b/roles/create_day2_cluster/tasks/main.yml
@@ -48,3 +48,59 @@
   delegate_to: "{{ item }}"
   delegate_facts: yes
   loop: "{{ groups['day2_workers'] }}"
+
+#### patch discovery ignition on restricted network environments ###
+
+- name: Load patch for search registries
+  set_fact:
+    search_registries: "{{ lookup('template', 'patch-search-registries.j2') }}"
+  when: disconnected | bool == True
+
+- name: Load patch for discovery ignition
+  set_fact:
+    patch_discovery_ignition: "{{ lookup('template', 'patch-discovery-ignition.j2') }}"
+  when: disconnected | bool == True
+
+- name: Patch discovery ignition
+  uri:
+    #url: "{{ URL_ASSISTED_INSTALLER_CLUSTERS }}/{{ cluster_id }}/discovery-ignition"
+    url: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ add_host_cluster_id }}/discovery-ignition"
+    method: PATCH
+    status_code: [201]
+    return_content: True
+    body_format: json
+    body:
+      {
+        "config": "{{ patch_discovery_ignition | to_json(ensure_ascii=False) | string }}",
+      }
+  when: disconnected | bool == True
+  register: http_reply
+
+#### patch cluster install config on restricted network environments ###
+
+- name: Load patch for install config
+  set_fact:
+    patch_install_config: "{{ lookup('template', 'patch-install-config.j2') | from_yaml }}"
+  when: disconnected | bool == True
+
+- name: Add network_type to patch_install_config
+  set_fact:
+    patch_install_config: "{{ lookup('template', 'patch-network-type.j2') | from_yaml | combine(patch_install_config | default({}))  }}"
+  when: network_type is defined
+
+- name: Patch install config
+  uri:
+    #url: "{{ URL_ASSISTED_INSTALLER_CLUSTERS }}/{{ cluster_id }}/install-config"
+    url: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ add_host_cluster_id }}/install-config"
+    method: PATCH
+    status_code: [201]
+    return_content: True
+    body_format: json
+    body: "{{ patch_install_config | to_json(ensure_ascii=False) | string | to_json(ensure_ascii=False) | string }}"
+  when: patch_install_config is defined
+  register: http_reply
+
+- name: Apply manifests before cluster installation
+  include_tasks: manifest.yml
+  loop: "{{ manifest_templates }}"
+  when: manifests | bool == True

--- a/roles/create_day2_cluster/tasks/manifest.yml
+++ b/roles/create_day2_cluster/tasks/manifest.yml
@@ -1,0 +1,34 @@
+---
+# tasks file for manifests
+
+- name: Load manifest
+  set_fact:
+    manifest: "{{ lookup('template', '{{ item }}.j2' ) }}"
+  when: manifests | bool == True
+
+- debug: # noqa unnamed-task
+    var: manifest
+    verbosity: 1
+  when: manifests | bool == True
+
+- name: Apply manifest
+  uri:
+    # url: "{{ URL_ASSISTED_INSTALLER_CLUSTERS }}/{{ cluster_id }}/manifests"
+    url: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ add_host_cluster_id }}/manifests"
+    method: POST
+    status_code: [201]
+    return_content: True
+    body_format: json
+    body:
+      {
+        "folder": "manifests",
+        "file_name": "{{ item }}",
+        "content": "{{ manifest | string | b64encode }}",
+      }
+  when: manifests | bool == True
+  register: http_reply
+
+- debug: # noqa unnamed-task
+    var: http_reply
+    verbosity: 1
+  when: manifests | bool == True

--- a/roles/create_day2_cluster/templates/50-worker-nm-fix-ipv6.yml.j2
+++ b/roles/create_day2_cluster/templates/50-worker-nm-fix-ipv6.yml.j2
@@ -1,0 +1,18 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-worker-nm-fix-duid
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,W21haW5dCnJjLW1hbmFnZXI9ZmlsZQpbY29ubmVjdGlvbl0KaXB2Ni5kaGNwLWR1aWQ9bGwKaXB2Ni5kaGNwLWlhaWQ9bWFjCg==
+            verification: {}
+          filesystem: root
+          mode: 420
+          path: /etc/NetworkManager/conf.d/99-upi-duid.conf

--- a/roles/create_day2_cluster/templates/50-worker-remove-ipi-leftovers.yml.j2
+++ b/roles/create_day2_cluster/templates/50-worker-remove-ipi-leftovers.yml.j2
@@ -1,0 +1,30 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-worker-remove-ipi-leftovers
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+        - contents:
+            source: data:,
+            verification: {}
+          filesystem: root
+          mode: 420
+          path: /etc/kubernetes/manifests/coredns.yaml
+        - contents:
+            source: data:,
+            verification: {}
+          filesystem: root
+          mode: 420
+          path: /etc/kubernetes/manifests/keepalived.yaml
+        - contents:
+            source: data:,
+            verification: {}
+          filesystem: root
+          mode: 420
+          path: /etc/kubernetes/manifests/mdns-publisher.yaml

--- a/roles/create_day2_cluster/templates/patch-discovery-ignition.j2
+++ b/roles/create_day2_cluster/templates/patch-discovery-ignition.j2
@@ -1,0 +1,31 @@
+{
+	"ignition": {
+		"version": "3.1.0"
+	},
+	"storage": {
+		"files": [
+			{
+				"path": "/etc/containers/registries.conf",
+				"mode": 420,
+				"overwrite": true,
+				"user": {
+					"name": "root"
+				},
+				"contents": {
+					"source": "data:text/plain;base64,{{ search_registries | string | b64encode }}"
+				}
+			},
+			{
+				"path": "/etc/pki/ca-trust/source/anchors/domain.crt",
+				"mode": 420,
+				"overwrite": true,
+				"user": {
+					"name": "root"
+				},
+				"contents": {
+					"source": "data:text/plain;base64,{{ mirror_certificate | string | b64encode }}"
+				}
+			}
+		]
+	}
+}

--- a/roles/create_day2_cluster/templates/patch-install-config.j2
+++ b/roles/create_day2_cluster/templates/patch-install-config.j2
@@ -1,0 +1,13 @@
+imageContentSources:
+- mirrors:
+  - {{ mirror_registry }}/ocp4/openshift4
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - {{ mirror_registry }}/ocp4/openshift4
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - {{ mirror_registry }}/ocpmetal
+  source: quay.io/ocpmetal
+additionalTrustBundle: |
+{{ mirror_certificate.split("\n") | map("regex_replace", "^(?!\s{4})", "    ") | list | join("\n") }}
+sshKey: {{ ssh_public_key }}

--- a/roles/create_day2_cluster/templates/patch-network-type.j2
+++ b/roles/create_day2_cluster/templates/patch-network-type.j2
@@ -1,0 +1,2 @@
+networking:
+  networkType: {{ network_type }}

--- a/roles/create_day2_cluster/templates/patch-search-registries.j2
+++ b/roles/create_day2_cluster/templates/patch-search-registries.j2
@@ -1,0 +1,19 @@
+unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
+[[registry]]
+   prefix = ""
+   location = "quay.io/ocpmetal"
+   mirror-by-digest-only = false
+   [[registry.mirror]]
+   location = "{{ mirror_registry }}/ocpmetal"
+[[registry]]
+   prefix = ""
+   location = "quay.io/openshift-release-dev/ocp-release"
+   mirror-by-digest-only = true
+   [[registry.mirror]]
+   location = "{{ mirror_registry }}/ocp4/openshift4"
+[[registry]]
+   prefix = ""
+   location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+   mirror-by-digest-only = true
+   [[registry.mirror]]
+   location = "{{ mirror_registry }}/ocp4/openshift4"


### PR DESCRIPTION
Currently the day2 worker playbook is broken for disconnected installs
as the patching logic for mirrored registries does not exist. This
commit fixes this although its mostly a copy of the templates from
the main create cluster role so probably can be done a lot nicer.
Also, the CSR approval mechanism is still broken.