### PR TITLE
Extend deployment plan output with more details

### DIFF
--- a/inventory.yml.sample
+++ b/inventory.yml.sample
@@ -65,7 +65,7 @@ all:
 
     # HTTP Store Configuration
     # ISO name must include the `discovery` directory if you have a SuperMicro machine
-    discovery_iso_name: "discovery/discovery-image.iso"
+    discovery_iso_name: "discovery/{{ cluster_name }}/discovery-image.iso"
 
     # discovery_iso_server must be discoverable from all BMCs in order for them to mount the ISO hosted there.
     # It is usually necessary to specify different values for KVM nodes and/or physical BMCs if they are on different subnets.

--- a/roles/display_deployment_plan/tasks/main.yml
+++ b/roles/display_deployment_plan/tasks/main.yml
@@ -9,7 +9,7 @@
       vars:
         # Every row consists of two columns. To ensure all items in the right column are aligned,
         # a minimum width of the left column is set in the following variable.
-        left_column_width: 26
+        left_column_width: 36
         row_format_str: '%-{{ left_column_width }}s %s'
         # To improve readability, all hosts listed in the "Groups and hosts configuration" section
         # are nested under groups by the number of spaces defined in the variable below.

--- a/roles/display_deployment_plan/tasks/main.yml
+++ b/roles/display_deployment_plan/tasks/main.yml
@@ -36,11 +36,15 @@
           base_dns_domain: "{{ base_dns_domain | default(messages.value_missing) }}"
           api_vip: "{{ api_vip | default(messages.value_missing) }}"
           ingress_vip: "{{ ingress_vip | default(messages.value_missing) }}"
+          vip_dhcp_allocation: "{{ vip_dhcp_allocation | default(messages.value_missing) }}"
           openshift_full_version: "{{ openshift_full_version | default(messages.value_missing) }}"
           setup_ntp_service: "{{ setup_ntp_service | default(messages.value_missing) }}"
           setup_dns_service: "{{ setup_dns_service | default(messages.value_missing) }}"
           setup_registry_service: "{{ setup_registry_service | default(messages.value_missing) }}"
           setup_http_store_service: "{{ setup_http_store_service | default(messages.value_missing) }}"
+          setup_assisted_installer: "{{ setup_assisted_installer | default(messages.value_missing) }}"
+          discovery_iso_name: "{{ discovery_iso_name | default(messages.value_missing) }}"
+          discovery_iso_download_path: "{{ iso_download_dest_path | default(messages.value_missing) }}"
           groups_filtered: "{{ groups | difference(groups_to_exclude) }}"
       register: display_deployment_plan__confirmation
 

--- a/roles/display_deployment_plan/templates/plan.j2
+++ b/roles/display_deployment_plan/templates/plan.j2
@@ -5,10 +5,14 @@ An OpenShift cluster is about to be deployed. Please double check the provided i
     {{ row_format_str | format('Cluster name', inventory.cluster_name) }}
     {{ row_format_str | format('Base DNS domain', inventory.base_dns_domain) }}
 
+    {{ row_format_str | format('OpenShift version', inventory.openshift_full_version) }}
+
+* Cluster network configuration
+
     {{ row_format_str | format('API Virtual IP', inventory.api_vip) }}
     {{ row_format_str | format('Ingress Virtual IP', inventory.ingress_vip) }}
 
-    {{ row_format_str | format('OpenShift version', inventory.openshift_full_version) }}
+    {{ row_format_str | format('Allocate Virtual IPs via DHCP', inventory.vip_dhcp_allocation) }}
 
 * Prerequisite services configuration
 
@@ -16,6 +20,9 @@ An OpenShift cluster is about to be deployed. Please double check the provided i
     {{ row_format_str | format('Setup DNS Service', inventory.setup_dns_service) }}
     {{ row_format_str | format('Setup Registry Service', inventory.setup_registry_service) }}
     {{ row_format_str | format('Setup HTTP Store Service', inventory.setup_http_store_service) }}
+
+    {{ row_format_str | format('Discovery ISO Name', inventory.discovery_iso_name) }}
+    {{ row_format_str | format('Discovery ISO Download Path', inventory.discovery_iso_download_path) }}
 
 * Groups and hosts configuration
 

--- a/roles/display_deployment_plan/templates/plan.j2
+++ b/roles/display_deployment_plan/templates/plan.j2
@@ -2,46 +2,47 @@ An OpenShift cluster is about to be deployed. Please double check the provided i
 
 * General configuration
 
-    {{ row_format_str | format('Cluster name', inventory.cluster_name) }}
-    {{ row_format_str | format('Base DNS domain', inventory.base_dns_domain) }}
+  {{ row_format_str | format('Cluster name', inventory.cluster_name) }}
+  {{ row_format_str | format('Base DNS domain', inventory.base_dns_domain) }}
 
-    {{ row_format_str | format('OpenShift version', inventory.openshift_full_version) }}
+  {{ row_format_str | format('OpenShift version', inventory.openshift_full_version) }}
 
 * Cluster network configuration
 
-    {{ row_format_str | format('API Virtual IP', inventory.api_vip) }}
-    {{ row_format_str | format('Ingress Virtual IP', inventory.ingress_vip) }}
+  {{ row_format_str | format('API Virtual IP', inventory.api_vip) }}
+  {{ row_format_str | format('Ingress Virtual IP', inventory.ingress_vip) }}
 
-    {{ row_format_str | format('Allocate Virtual IPs via DHCP', inventory.vip_dhcp_allocation) }}
+  {{ row_format_str | format('Allocate Virtual IPs via DHCP', inventory.vip_dhcp_allocation) }}
 
 * Prerequisite services configuration
 
-    {{ row_format_str | format('Setup NTP Service', inventory.setup_ntp_service) }}
-    {{ row_format_str | format('Setup DNS Service', inventory.setup_dns_service) }}
-    {{ row_format_str | format('Setup Registry Service', inventory.setup_registry_service) }}
-    {{ row_format_str | format('Setup HTTP Store Service', inventory.setup_http_store_service) }}
+  {{ row_format_str | format('Setup NTP Service', inventory.setup_ntp_service) }}
+  {{ row_format_str | format('Setup DNS Service', inventory.setup_dns_service) }}
+  {{ row_format_str | format('Setup Registry Service', inventory.setup_registry_service) }}
+  {{ row_format_str | format('Setup HTTP Store Service', inventory.setup_http_store_service) }}
+  {{ row_format_str | format('Setup Assisted Installer', inventory.setup_assisted_installer) }}
 
-    {{ row_format_str | format('Discovery ISO Name', inventory.discovery_iso_name) }}
-    {{ row_format_str | format('Discovery ISO Download Path', inventory.discovery_iso_download_path) }}
+  {{ row_format_str | format('Discovery ISO Name', inventory.discovery_iso_name) }}
+  {{ row_format_str | format('Discovery ISO Download Path', inventory.discovery_iso_download_path) }}
 
 * Groups and hosts configuration
 
-  {% for group_name in inventory.groups_filtered %}
+{% for group_name in inventory.groups_filtered %}
   {{ group_name }}:
-  {% for host_name in groups[group_name] %}
-  {%- set host_ansible_host = hostvars[host_name]['ansible_host'] | default(messages.value_missing) -%}
-  {% if hostvars[host_name]['vm_host'] is defined %}
-  {{ hosts_row_extended_format_str | format(host_name, host_ansible_host, hostvars[host_name]['vm_host']) }}
-  {% else %}
-  {{ hosts_row_format_str | format(host_name, host_ansible_host) }}
-  {% endif -%}
-  {% else %}
-  {{ messages.hosts_missing }}
-  {% endfor -%}
-  {% else %}
-  {{ messages.groups_missing }}
-  {% endfor -%}
-
+{% for host_name in groups[group_name] %}
+{% set host_ansible_host = hostvars[host_name]['ansible_host'] | default(messages.value_missing) %}
+{% if hostvars[host_name]['vm_host'] is defined %}
+    {{ hosts_row_extended_format_str | format(host_name, host_ansible_host, hostvars[host_name]['vm_host']) }}
+{% else %}
+    {{ hosts_row_format_str | format(host_name, host_ansible_host) }}
+{% endif %}
+{% else %}
+    {{ messages.hosts_missing }}
+{% endfor %}
+{# This adds a newline character between groups #}{{ '' }}
+{% else %}
+  {{ messages.groups_missing }}{{ '\n' }}
+{% endfor %}
 ---
 
 Are you sure you want to proceed with the deployment using this inventory configuration?


### PR DESCRIPTION
This change adds the following values to the plan's output:
- VIP DHCP Allocation (bool)
- Assisted Installer Setup (bool)
- Discovery ISO Name (string)
- Discovery ISO Download Path (string)

The output was updated to display the new path for ISOs, which from now on includes the cluster name in the path.

Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>