### PR TITLE
Add support for Single Node OpenShift deployments

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -20,8 +20,20 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 
 ### Cluster config checks:
 
+#### Highly Available OpenShift cluster node checks
+
 - 3 or more master nodes
 - 2 or more, or 0 worker nodes
+
+#### Single Node OpenShift cluster node checks
+
+- 1 master node
+- 0 worker nodes
+
+Single Node OpenShift requires the API and Ingress VIPs to be set to the IP address (`ansible_host`) of the master node.
+
+In addition to that, the following checks must be met for both HA and SNO deployments:
+
 - every node has required vars:
   - `bmc_address`
   - `bmc_password`

--- a/inventory.yml.sample
+++ b/inventory.yml.sample
@@ -124,6 +124,8 @@ all:
 
     openshift_version: "{{ openshift_full_version.split('.')[:2] | join('.') }}"
 
+    is_valid_single_node_openshift_config: "{{ (groups['nodes'] | length == 1) and (groups['masters'] | length == 1) }}"
+
     ############################
     # ^^^^^^^^^^^^^^^^^^^^^^^^ #
     #    LOGIC: DO NOT TOUCH   #

--- a/post_install.yml
+++ b/post_install.yml
@@ -8,6 +8,10 @@
     kube_filename: "{{ kubeconfig_dest_filename | default('kubeconfig') }}"
     dest_dir: "{{ kubeconfig_dest_dir | default(ansible_env.HOME) }}"
     kubeconfig_path: "{{ dest_dir }}/{{ kube_filename }}"
+
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+
   tasks:
     - name: Download kubeconfig
       get_url:
@@ -15,18 +19,18 @@
         dest: "{{ kubeconfig_path }}"
         mode: 0664
 
-    - name: Check kubectl
+    - name: Perform simple connectivity check with oc
       shell:
-        cmd: "kubectl --kubeconfig {{ kubeconfig_path }} explain pods"
+        cmd: "oc explain pods"
 
-    - name: Check cluster
+    - name: Check status of cluster operators
       block:
-        - name: Wait up to 10 mins for cluster to become functional
+        - name: Wait up to 20 mins for cluster to become functional
           shell:
-            cmd: oc --kubeconfig {{ kubeconfig_path }} wait clusteroperators --all --for=condition=Available --timeout=10m
+            cmd: oc wait clusteroperators --all --for=condition=Available --timeout=20m
       rescue:
         - name: Get better info for failure message
-          shell: oc --kubeconfig {{ kubeconfig_path }} get co
+          shell: oc get clusteroperators
           register: co_result
 
         - fail:
@@ -42,4 +46,4 @@
 
     - name: Login to add token to kubeconfig
       shell:
-        cmd: "oc --kubeconfig {{ kubeconfig_path }} login -u {{ credentials.json.username }} -p '{{ credentials.json.password }}'"
+        cmd: "oc login -u {{ credentials.json.username }} -p '{{ credentials.json.password }}'"

--- a/roles/create_cluster/defaults/main.yml
+++ b/roles/create_cluster/defaults/main.yml
@@ -20,8 +20,26 @@ HTTP_PROXY: ""
 HTTPS_PROXY: ""
 NO_PROXY: ""
 
-manifest_templates:
-  - 50-worker-nm-fix-ipv6.yml
-  - 50-worker-remove-ipi-leftovers.yml
-  - 02-fix-ingress-config.yml
-  - 01-master-node-scheduler.yml
+single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"
+
+# Accepted values for "High Availability Mode"
+#
+# 1. 'None' (when `is_valid_single_node_openshift_config` evaluates to True)
+#     Requires one master node and no worker nodes -- SNO.
+# 2. 'Full' (otherwise)
+#     Requires at least three master nodes for High Availability.
+high_availability_mode: "{{ single_node_openshift_enabled | ternary('none', 'full') }}"
+
+manifest_templates_for_mode:
+  none:
+    - 50-worker-nm-fix-ipv6.yml
+    - 50-worker-remove-ipi-leftovers.yml
+    # - 02-fix-ingress-config.yml     # Applying this fix breaks the ingress controller on SNO.
+    # - 01-master-node-scheduler.yml  # The master node on SNO is automatically marked as schedulable.
+  full:
+    - 50-worker-nm-fix-ipv6.yml
+    - 50-worker-remove-ipi-leftovers.yml
+    - 02-fix-ingress-config.yml
+    - 01-master-node-scheduler.yml
+
+manifest_templates: "{{ manifest_templates_for_mode[high_availability_mode] }}"

--- a/roles/create_cluster/tasks/main.yml
+++ b/roles/create_cluster/tasks/main.yml
@@ -25,7 +25,7 @@
         "openshift_version": OPENSHIFT_VERSION,
         "base_dns_domain": BASE_DNS_DOMAIN,
         "cluster_network_cidr": CLUSTER_NETWORK_CIDR,
-        "cluster_network_host_prefix": 23,
+        "cluster_network_host_prefix": (CLUSTER_NETWORK_HOST_PREFIX | int),
         "service_network_cidr": SERVICE_NETWORK_CIDR,
         "pull_secret": (PULL_SECRET | to_json),
         "ssh_public_key": SSH_PUBLIC_KEY,

--- a/roles/create_cluster/tasks/main.yml
+++ b/roles/create_cluster/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 # tasks file for create_cluster
 
-# TODO: use the variable for cluster_network_host_prefix
 - name: Create cluster
   uri:
     url: "{{ URL_ASSISTED_INSTALLER_CLUSTERS }}"
@@ -11,24 +10,32 @@
     body_format: json
     status_code: [201]
     return_content: True
-    body:
-      {
-        "name": "{{ CLUSTER_NAME }}",
-        "openshift_version": "{{ OPENSHIFT_VERSION }}",
-        "base_dns_domain": "{{ BASE_DNS_DOMAIN }}",
-        "cluster_network_cidr": "{{ CLUSTER_NETWORK_CIDR }}",
+    # - `ingress_vip` is not provided in the request body because the value
+    #   can't be set for SNO with user-managed networking enabled.
+    #   HA clusters will be patched with the `ingress_vip` setting during
+    #   the execution of the `install_cluster` role.
+    # - the request body is wrapped in a jinja2 expression with the `to_json`
+    #   filter to prevent the `cluster_network_host_prefix` value from being
+    #   type casted to a string. The Assisted Installer API requires this
+    #   input field to be an integer.
+    body: >-
+      {{ {
+        "name": CLUSTER_NAME,
+        "high_availability_mode": (high_availability_mode | title),
+        "openshift_version": OPENSHIFT_VERSION,
+        "base_dns_domain": BASE_DNS_DOMAIN,
+        "cluster_network_cidr": CLUSTER_NETWORK_CIDR,
         "cluster_network_host_prefix": 23,
-        "service_network_cidr": "{{ SERVICE_NETWORK_CIDR }}",
-        "ingress_vip": "{{ INGRESS_VIP }}",
-        "pull_secret": "{{ PULL_SECRET | to_json }}",
-        "ssh_public_key": "{{ SSH_PUBLIC_KEY }}",
-        "vip_dhcp_allocation": "{{ VIP_DHCP_ALLOCATION | lower | bool }}",
-        "api_vip": "{{ API_VIP }}",
-        "http_proxy": "{{ HTTP_PROXY }}",
-        "https_proxy": "{{ HTTPS_PROXY }}",
-        "no_proxy": "{{ NO_PROXY }}",
-        "additional_ntp_source": "{{ NTP_SERVER }}",
-      }
+        "service_network_cidr": SERVICE_NETWORK_CIDR,
+        "pull_secret": (PULL_SECRET | to_json),
+        "ssh_public_key": SSH_PUBLIC_KEY,
+        "vip_dhcp_allocation": (VIP_DHCP_ALLOCATION | lower | bool),
+        "api_vip": API_VIP,
+        "http_proxy": HTTP_PROXY,
+        "https_proxy": HTTPS_PROXY,
+        "no_proxy": NO_PROXY,
+        "additional_ntp_source": NTP_SERVER,
+      } | to_json }}
   when: create | bool == True
   register: http_reply
 

--- a/roles/create_cluster/tasks/manifest.yml
+++ b/roles/create_cluster/tasks/manifest.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for manifests
 
-- name: Load manifest
+- name: "Load manifest ({{ item }})"
   set_fact:
     manifest: "{{ lookup('template', '{{ item }}.j2' ) }}"
   when: manifests | bool == True
@@ -11,7 +11,7 @@
     verbosity: 1
   when: manifests | bool == True
 
-- name: Apply manifest
+- name: "Apply manifest ({{ item }})"
   uri:
     url: "{{ URL_ASSISTED_INSTALLER_CLUSTERS }}/{{ cluster_id }}/manifests"
     method: POST

--- a/roles/display_deployment_plan/tasks/main.yml
+++ b/roles/display_deployment_plan/tasks/main.yml
@@ -45,6 +45,7 @@
           setup_assisted_installer: "{{ setup_assisted_installer | default(messages.value_missing) }}"
           discovery_iso_name: "{{ discovery_iso_name | default(messages.value_missing) }}"
           discovery_iso_download_path: "{{ iso_download_dest_path | default(messages.value_missing) }}"
+          is_valid_single_node_openshift_config: "{{ is_valid_single_node_openshift_config | default(messages.value_missing) }}"
           groups_filtered: "{{ groups | difference(groups_to_exclude) }}"
       register: display_deployment_plan__confirmation
 

--- a/roles/display_deployment_plan/templates/plan.j2
+++ b/roles/display_deployment_plan/templates/plan.j2
@@ -27,6 +27,8 @@ An OpenShift cluster is about to be deployed. Please double check the provided i
 
 * Groups and hosts configuration
 
+  {{ row_format_str | format('Single Node OpenShift (SNO) Mode', inventory.is_valid_single_node_openshift_config) }}
+
 {% for group_name in inventory.groups_filtered %}
   {{ group_name }}:
 {% for host_name in groups[group_name] %}

--- a/roles/install_cluster/defaults/main.yml
+++ b/roles/install_cluster/defaults/main.yml
@@ -14,3 +14,5 @@ HTTP_AUTH_USERNAME: "none"
 HTTP_AUTH_PASSWORD: "none"
 
 fetched_dest: "{{ repo_root_path }}/fetched"
+
+single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"

--- a/roles/install_cluster/tasks/main.yml
+++ b/roles/install_cluster/tasks/main.yml
@@ -58,22 +58,38 @@
     loop_var: discovered_host
   no_log: True
 
-# Patch the cluster with the API Virtual IP
-- name: Patch cluster with API Virtual IP
-  uri:
-    url: "{{ URL_ASSISTED_INSTALLER_CLUSTER }}"
-    method: PATCH
-    status_code: [201]
-    return_content: True
-    body_format: json
-    body:
-      {
+- name: Patch cluster with config vars relevant to the selected HA mode
+  when: (install | bool == True)
+  block:
+  - name: Set config vars for patching the cluster (SNO)
+    set_fact:
+      cluster_config_patch_request_body: {
+        "machine_network_cidr": "{{ machine_network_cidr }}",
+      }
+    when: single_node_openshift_enabled
+
+  - name: Set config vars for patching the cluster (HA)
+    set_fact:
+      cluster_config_patch_request_body: {
         "vip_dhcp_allocation": "{{ VIP_DHCP_ALLOCATION | lower | bool }}",
         "ingress_vip": "{{ INGRESS_VIP }}",
         "api_vip": "{{ API_VIP }}",
       }
-  when: install | bool == True
-  register: http_reply
+    when: not single_node_openshift_enabled
+
+  - debug: # noqa unnamed-task
+      var: cluster_config_patch_request_body
+      verbosity: 1
+
+  - name: "Patch cluster"
+    uri:
+      url: "{{ URL_ASSISTED_INSTALLER_CLUSTER }}"
+      method: PATCH
+      status_code: [201]
+      return_content: True
+      body_format: json
+      body: "{{ cluster_config_patch_request_body }}"
+    register: http_reply
 
 - debug: # noqa unnamed-task
     var: http_reply.json

--- a/roles/patch_host_config/defaults/main.yml
+++ b/roles/patch_host_config/defaults/main.yml
@@ -1,2 +1,4 @@
 ASSISTED_INSTALLER_BASE_URL: "{{ secure | ternary('https', 'http') }}://{{ hostvars['assisted_installer']['host'] }}:{{ hostvars['assisted_installer']['port'] }}/api/assisted-install/v1"
 URL_ASSISTED_INSTALLER_CLUSTER: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ cluster_id }}"
+
+single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"

--- a/roles/patch_host_config/tasks/main.yml
+++ b/roles/patch_host_config/tasks/main.yml
@@ -63,6 +63,8 @@
         "hosts_names": [ "{{ host }}" ],
         "hosts_roles": [ "{{ host }}" ]
     }
+  # Role can't be changed for SNO hosts
+  when: not single_node_openshift_enabled
   register: http_reply
 
 - name: Set the installation disk path

--- a/roles/validate_inventory/defaults/main.yml
+++ b/roles/validate_inventory/defaults/main.yml
@@ -25,3 +25,5 @@ supported_ocp_versions:
   - 4.7.33
   - 4.8.14
   - 4.9.0
+
+single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"

--- a/roles/validate_inventory/tasks/cluster.yml
+++ b/roles/validate_inventory/tasks/cluster.yml
@@ -5,11 +5,22 @@
       - openshift_full_version in supported_ocp_versions
     fail_msg: "We do not support that version of openshift"
 
-- name: Assert valid master configuration
+- name: Assert valid master configuration (HA)
   assert:
     that:
       - groups['masters'] | length >= 3
-    fail_msg: "There must be at least three masters defined."
+    fail_msg: "There must be at least three masters defined. To deploy SNO, define one master and no workers."
+  when: not single_node_openshift_enabled
+
+- name: Assert API and Ingress VIPs are set correctly (SNO)
+  assert:
+    that:
+      - api_vip == hostvars[sno_hostname]['ansible_host']
+      - ingress_vip == hostvars[sno_hostname]['ansible_host']
+    fail_msg: "For SNO deployments, API and Ingress VIPs need to match the IP address (ansible_host) of the master node."
+  vars:
+    sno_hostname: "{{ groups['masters'][0] }}"
+  when: single_node_openshift_enabled
 
 - name: Assert valid worker configuration
   assert:


### PR DESCRIPTION
From now on, end users can choose to deploy either a SNO or HA cluster.

SNO will be enabled automatically if and only if one master node and zero worker nodes are defined in the inventory.

Co-authored-by: Dylan Wong <dywong@redhat.com>
Signed-off-by: Marek Kochanowski <mkochanowski@redhat.com>