### PR TITLE
add boot flag so VM is restarted if host is rebooted

### DIFF
--- a/roles/create_vms/templates/create_vm.sh.j2
+++ b/roles/create_vms/templates/create_vm.sh.j2
@@ -19,6 +19,7 @@ virt-install \
     --wait=-1 \
     --boot uefi \
     --events on_reboot=restart \
+    --autostart \
     --print-xml > /tmp/{{item.name}}.xml
 
 virsh define --file /tmp/{{item.name}}.xml


### PR DESCRIPTION
VMs ideally should have the autostart flag set, so if the physical server host itself is rebooted, the VMs are restarted without user intervention.

Feel free of course to edit as you see fit...