### PR TITLE
Save kubeadmin credentials to a ansible vault

### DIFF
--- a/inventory.yml.sample
+++ b/inventory.yml.sample
@@ -101,6 +101,8 @@ all:
     # The retrieved cluster kubeconfig will be placed on the bastion host at the following location
     kubeconfig_dest_dir: /home/redhat/
     kubeconfig_dest_filename: "{{ cluster_name }}-kubeconfig"
+    kubeadmin_dest_filename: "{{ cluster_name }}-kubeadmin.vault.yml"
+    # You can comment out the line below if you want the kubeadmin credentials to be stored in plain text
     kubeadmin_vault_password_file_path: "{{ repo_root_path }}/kubeadmin_vault_password_file"
 
     ############################

--- a/inventory.yml.sample
+++ b/inventory.yml.sample
@@ -101,6 +101,7 @@ all:
     # The retrieved cluster kubeconfig will be placed on the bastion host at the following location
     kubeconfig_dest_dir: /home/redhat/
     kubeconfig_dest_filename: "{{ cluster_name }}-kubeconfig"
+    kubeadmin_vault_password_file_path: "{{ repo_root_path }}/kubeadmin_vault_password_file"
 
     ############################
     #    LOGIC: DO NOT TOUCH   #

--- a/post_install.yml
+++ b/post_install.yml
@@ -5,13 +5,12 @@
     secure: false
     ASSISTED_INSTALLER_BASE_URL: "{{ secure | ternary('https', 'http') }}://{{ hostvars['assisted_installer']['host'] }}:{{ hostvars['assisted_installer']['port'] }}/api/assisted-install/v1"
     URL_ASSISTED_INSTALLER_CLUSTER: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ cluster_id }}"
-    kube_filename: "{{ kubeconfig_dest_filename | default('kubeconfig') }}"
+    kube_filename: "{{ kubeconfig_dest_filename | default(cluster_name + '-kubeconfig') }}"
     dest_dir: "{{ kubeconfig_dest_dir | default(ansible_env.HOME) }}"
     kubeconfig_path: "{{ dest_dir }}/{{ kube_filename }}"
-
+    kubeadmin_vault_name: "{{ cluster_name }}-kubeadmin.vault.yml"
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
-
   tasks:
     - name: Download kubeconfig
       get_url:
@@ -47,3 +46,12 @@
     - name: Login to add token to kubeconfig
       shell:
         cmd: "oc login -u {{ credentials.json.username }} -p '{{ credentials.json.password }}'"
+
+    - name: Save credentials to file
+      copy:
+        content: "{{ credentials.json | to_yaml }}"
+        dest: "{{ dest_dir }}/{{ kubeadmin_vault_name }}"
+
+    - name: Save credentials to vault
+      shell:
+        cmd: "ansible-vault encrypt --vault-password-file {{ kubeadmin_vault_password_file_path }} {{ dest_dir }}/{{ kubeadmin_vault_name }}"

--- a/post_install.yml
+++ b/post_install.yml
@@ -8,7 +8,7 @@
     kube_filename: "{{ kubeconfig_dest_filename | default(cluster_name + '-kubeconfig') }}"
     dest_dir: "{{ kubeconfig_dest_dir | default(ansible_env.HOME) }}"
     kubeconfig_path: "{{ dest_dir }}/{{ kube_filename }}"
-    kubeadmin_vault_name: "{{ cluster_name }}-kubeadmin.vault.yml"
+    kubeadmin_vault_name: "{{ kubeadmin_dest_filename | default(cluster_name +'-kubeadmin.vault.yml') }}"
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
   tasks:
@@ -55,3 +55,4 @@
     - name: Save credentials to vault
       shell:
         cmd: "ansible-vault encrypt --vault-password-file {{ kubeadmin_vault_password_file_path }} {{ dest_dir }}/{{ kubeadmin_vault_name }}"
+      when: (kubeadmin_vault_password_file_path is defined) and (kubeadmin_vault_password_file_path is file)

--- a/roles/display_deployment_plan/tasks/main.yml
+++ b/roles/display_deployment_plan/tasks/main.yml
@@ -28,6 +28,7 @@
           value_missing: "<not set>"
           hosts_missing: "<no hosts set>"
           groups_missing: "<no groups set>"
+          kubeadmin_vault_password_file_path_missing: "UNDEFINED (This means the kubeadmin credentals will be stored in plain text)"
         # A default error message is assigned to each variable referenced in the deployment plan.
         # This prevents the prompt from not being displayed due to templating errors if a valid
         # inventory file is not provided.
@@ -47,6 +48,7 @@
           discovery_iso_download_path: "{{ iso_download_dest_path | default(messages.value_missing) }}"
           is_valid_single_node_openshift_config: "{{ is_valid_single_node_openshift_config | default(messages.value_missing) }}"
           groups_filtered: "{{ groups | difference(groups_to_exclude) }}"
+          kubeadmin_vault_password_file_path: "{{ kubeadmin_vault_password_file_path | default(messages.kubeadmin_vault_password_file_path_missing) }}"
       register: display_deployment_plan__confirmation
 
     - name: Assert the deployment plan is confirmed

--- a/roles/display_deployment_plan/templates/plan.j2
+++ b/roles/display_deployment_plan/templates/plan.j2
@@ -7,6 +7,8 @@ An OpenShift cluster is about to be deployed. Please double check the provided i
 
   {{ row_format_str | format('OpenShift version', inventory.openshift_full_version) }}
 
+  {{ row_format_str | format('Kube admin vault password file', inventory.kubeadmin_vault_password_file_path }}
+
 * Cluster network configuration
 
   {{ row_format_str | format('API Virtual IP', inventory.api_vip) }}

--- a/roles/validate_inventory/tasks/required_vars.yml
+++ b/roles/validate_inventory/tasks/required_vars.yml
@@ -8,7 +8,7 @@
 - name: Check kubeadmin_vault_password_file_path is defined and the file exists
   assert:
     that:
-      - kubeadmin_vault_password_file_path is defined
       - kubeadmin_vault_password_file_path is file
     fail_msg: "Kubeadmin Vault password must be stored in the location specified by the required variable 'kubeadmin_vault_password_file_path'."
   changed_when: False
+  when:  kubeadmin_vault_password_file_path is defined

--- a/roles/validate_inventory/tasks/required_vars.yml
+++ b/roles/validate_inventory/tasks/required_vars.yml
@@ -4,3 +4,11 @@
       - repo_root_path is defined
     fail_msg: repo_root_path is required for all playbooks to function correctly
   changed_when: False
+
+- name: Check kubeadmin_vault_password_file_path is defined and the file exists
+  assert:
+    that:
+      - kubeadmin_vault_password_file_path is defined
+      - kubeadmin_vault_password_file_path is file
+    fail_msg: "Kubeadmin Vault password must be stored in the location specified by the required variable 'kubeadmin_vault_password_file_path'."
+  changed_when: False


### PR DESCRIPTION
Requires a new variable which `kubeadmin_vault_password_file_path` which defines the path to file containing the password for the vault