### PR TITLE
add Cleanup of /tmp/ssh_keys folder

### DIFF
--- a/roles/generate_ssh_key_pair/tasks/main.yml
+++ b/roles/generate_ssh_key_pair/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: "Remove temporary ssh_keys folder {{ key_pair_dir }}"
+  file:
+    path: "{{ key_pair_dir }}"
+    state: absent
+
 - name: Make key dir
   file:
     path: "{{ key_pair_dir }}"


### PR DESCRIPTION
The play failed after running. The reason for the failure is that the file already exists with different permissions because of being created by a different user running crucible.
The file is also copied to the home directory of the user and doesn't use the /tmp directory anymore.
I would like to add a task to delete the files from the tmp folder.
