### PR TITLE
Moves Ansible boot override mode to redfish_command

### DIFF
--- a/roles/boot_disk/tasks/hpe.yml
+++ b/roles/boot_disk/tasks/hpe.yml
@@ -19,21 +19,15 @@
     resource_id: 1
   ignore_errors: yes
 
-# Redfish module doesn't appear to support setting both options at once which ILO requires
-- name: Set HPE OneTimeBoot Hdd # noqa var-spacing
-  uri:
-    url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Systems/1"
-    user: "{{ hostvars[item]['bmc_user'] }}"
-    password: "{{ hostvars[item]['bmc_password'] }}"
-    method: PATCH
-    headers:
-      content-type: application/json
-      Accept: application/json
-    body: '{"Boot":{"BootSourceOverrideEnabled":"Continuous","BootSourceOverrideTarget":"Hdd"}}'
-    body_format: json
-    force_basic_auth: yes
-    validate_certs: no
-    return_content: yes
+- name: Set HPE OneTimeBoot Hdd
+  community.general.redfish_command:
+    category: Systems
+    command: SetOneTimeBoot
+    bootdevice: Hdd
+    baseuri: "{{ hostvars[inventory_hostname]['bmc_address'] }}"
+    username: "{{ hostvars[inventory_hostname]['bmc_user'] }}"
+    password: "{{ hostvars[inventory_hostname]['bmc_password'] }}"
+    resource_id: 1
 
 # ILO appears to use a custom url for Reset so we cannot use the redfish module here
 - name: HPE Restart system power forcefully

--- a/roles/boot_iso/tasks/hpe.yml
+++ b/roles/boot_iso/tasks/hpe.yml
@@ -73,21 +73,15 @@
             - CD
         resource_id: 1
 
-    # Redfish module doesn't appear to support setting both options at once which ILO requires
-    - name: Set Boot for the HPE # noqa var-spacing
-      uri:
-        url: "https://{{ hostvars[inventory_hostname]['bmc_address'] }}/redfish/v1/Systems/1"
-        user: "{{ hostvars[inventory_hostname]['bmc_user'] }}"
+    - name: HPE Set boot source override
+      community.general.redfish_command:
+        category: Systems
+        command: SetOneTimeBoot
+        bootdevice: Cd
+        baseuri: "{{ hostvars[inventory_hostname]['bmc_address'] }}"
+        username: "{{ hostvars[inventory_hostname]['bmc_user'] }}"
         password: "{{ hostvars[inventory_hostname]['bmc_password'] }}"
-        method: PATCH
-        headers:
-          content-type: application/json
-          Accept: application/json
-        body: '{"Boot":{"BootSourceOverrideEnabled":"Once","BootSourceOverrideTarget":"Cd"}}'
-        body_format: json
-        force_basic_auth: yes
-        validate_certs: no
-        return_content: yes
+        resource_id: 1
 
     - name: HPE Power On the System {{ inventory_hostname }}
       community.general.redfish_command:


### PR DESCRIPTION
With community.general 3.5.0, redfish_command supports overriding
the boot mode so lets use that rather than the uri module. This
should apply to other hardware vendors but I only have access to
ILO to test currently.