### PR TITLE
Including day2 workers when inserting dns records

### DIFF
--- a/roles/insert_dns_records/tasks/main.yml
+++ b/roles/insert_dns_records/tasks/main.yml
@@ -13,7 +13,7 @@
       }
     )
     }}"
-  loop: "{{ groups['masters'] + groups['workers'] | default([]) }}"
+  loop: "{{ groups['nodes'] }}"
   when: hostvars[item][host_ip_keyword] is defined
 
 - name: Configure firewall


### PR DESCRIPTION
Fixing a bug where day2 workers were not included in the loop when inserting DNS records