### PR TITLE
Removing hard-coded sushy-tools path

### DIFF
--- a/roles/setup_sushy_tools/templates/sushy-tools.service.j2
+++ b/roles/setup_sushy_tools/templates/sushy-tools.service.j2
@@ -5,8 +5,8 @@ After=network.target syslog.target
 [Service]
 Type=simple
 TimeoutStartSec=5m
-WorkingDirectory=/opt/sushy-tools
-ExecStart=/usr/local/bin/sushy-emulator --config /opt/sushy-tools/sushy-emulator.conf
+WorkingDirectory={{ sushy_dir }}
+ExecStart=/usr/local/bin/sushy-emulator --config {{ sushy_dir }}/sushy-emulator.conf
 Restart=always
 
 [Install]


### PR DESCRIPTION
You can set the `sushy_dir` variable, but the service file still pointed
to a static `/opt/sushy-tools` path.