### PR TITLE
Add listen_local flag to dnsmaqs

### DIFF
--- a/roles/insert_dns_records/defaults/main.yml
+++ b/roles/insert_dns_records/defaults/main.yml
@@ -21,3 +21,4 @@ use_dhcp: false
 dhcp_lease_time: 24h
 
 listen_address: "{{ ansible_default_ipv4.address }}"
+listen_local: true

--- a/roles/insert_dns_records/templates/openshift-cluster.conf.j2
+++ b/roles/insert_dns_records/templates/openshift-cluster.conf.j2
@@ -2,7 +2,7 @@ domain={{ domain }}
 {% if write_dnsmasq_config %}
 domain-needed
 bogus-priv
-listen-address=127.0.0.1,{{ listen_address }}
+listen-address={% if listen_local %}127.0.0.1,{% endif %}{{ listen_address }}
 expand-hosts
 {% if upstream_dns | default(False) %}
 server={{ upstream_dns }}


### PR DESCRIPTION
When set to false, 127.0.0.1 will not be added to listen-address in dnsmasq