### PR TITLE
Fixes issues with port parsing

### DIFF
--- a/roles/setup_http_store/tasks/main.yml
+++ b/roles/setup_http_store/tasks/main.yml
@@ -34,7 +34,7 @@
       containers.podman.podman_pod:
         name: "{{ http_store_pod_name }}"
         publish:
-          - 80:8080
+          - "80:8080"
       register: pod_info
 
     - debug: # noqa unnamed-task


### PR DESCRIPTION
It seems there is an issue with later podman and its being
interpreted incorrectly. So we add quotes to ensure the colon
is part of the string.