### PR TITLE
Deploy virtual network before dns

### DIFF
--- a/deploy_prerequisites.yml
+++ b/deploy_prerequisites.yml
@@ -12,10 +12,10 @@
 
 - import_playbook: playbooks/deploy_registry.yml
 
+- import_playbook: playbooks/create_vms.yml
+
 - import_playbook: playbooks/deploy_dns.yml
 
 - import_playbook: playbooks/deploy_assisted_installer_onprem.yml
-
-- import_playbook: playbooks/create_vms.yml
 
 - import_playbook: playbooks/deploy_sushy_tools.yml


### PR DESCRIPTION
If using the network bridge specified in the virtual environment the dns
role will reference it before it's been created which will cause dnsmasq
to fail to run.  This will break all dns lookups until fixed.

This PR deploys the virtual resources before the dns role.