### PR TITLE
Install manual binaries in /usr/local/bin

### DIFF
--- a/roles/populate_mirror_registry/tasks/populate_registry.yml
+++ b/roles/populate_mirror_registry/tasks/populate_registry.yml
@@ -22,7 +22,7 @@
 
     - name: Mirror remote ocpmetal image registry to local
       command: >
-        /usr/bin/oc image mirror
+        /usr/local/bin/oc image mirror
         -a "{{ config_file_path }}/{{ pull_secret_file_name }}"
         {{ item.remote }}
         {{ item.local }}:{{ item.local_tag }}
@@ -30,7 +30,7 @@
 
     - name: Mirror remote registry to local
       command: >
-        /usr/bin/oc adm release mirror
+        /usr/local/bin/oc adm release mirror
           -a "{{ config_file_path }}/{{ pull_secret_file_name }}"
           --from="{{ release_image_item.remote | quote }}"
           --to-release-image="{{ release_image_item.local | quote }}:{{ release_image_item.local_tag | quote }}"

--- a/roles/populate_mirror_registry/tasks/prerequisites.yml
+++ b/roles/populate_mirror_registry/tasks/prerequisites.yml
@@ -55,31 +55,24 @@
         remote_src: yes
       become: true
 
-    - name: Move oc to /usr/bin
+    - name: Move binary to /usr/local/bin
       copy:
-        src: "{{ downloads_path }}/openshift-client-linux/oc"
-        dest: /usr/bin/oc
+        src: "{{ downloads_path }}/openshift-client-linux/{{ item }}"
+        dest: "/usr/local/bin/{{ item }}"
         owner: "{{ file_owner }}"
         group: "{{ file_group }}"
         mode: 0775
         remote_src: yes
       become: true
+      with_items:
+        - kubectl
+        - oc
 
-    - name: Move kubectl to /usr/bin
-      copy:
-        src: "{{ downloads_path }}/openshift-client-linux/kubectl"
-        dest: /usr/bin/kubectl
-        owner: "{{ file_owner }}"
-        group: "{{ file_group }}"
-        mode: 0775
-        remote_src: yes
-      become: true
-
-    - name: Check kubectl installed
-      command: /usr/bin/kubectl version
-
-    - name: Check oc installed
-      command: /usr/bin/oc version
+    - name: Check binary installed
+      command: "/usr/local/bin/{{ item }} version"
+      with_items:
+        - kubectl
+        - oc
 
   tags:
     - create_registry
@@ -110,10 +103,10 @@
         group: "{{ file_group }}"
         remote_src: yes
 
-    - name: Move opm to /usr/bin
+    - name: Move opm to /usr/local/bin
       copy:
         src: "{{ downloads_path }}/opm-linux/opm"
-        dest: /usr/bin/opm
+        dest: /usr/local/bin/opm
         owner: "{{ file_owner }}"
         group: "{{ file_group }}"
         mode: 0775
@@ -121,7 +114,7 @@
       become: true
 
     - name: Check opm installed
-      command: opm version
+      command: /usr/local/bin/opm version
   tags:
     - create_registry
     - fetch_opm


### PR DESCRIPTION
One of the requirements says to install the `openshift-clients` package,
which provides `/usr/bin/{kubectl,oc}`. Then when populating the
registry we download the binaries according to the version to be
installed, then overwrite them on top of the ones in `/usr/bin`. It's
probably better to keep the integrity of the RPM DB and install them to
`/usr/local/bin` instead.