### PR TITLE
Candidate and dev/nightly builds support

### DIFF
--- a/roles/boot_iso/tasks/kvm.yml
+++ b/roles/boot_iso/tasks/kvm.yml
@@ -77,6 +77,7 @@
     force_basic_auth: no
     validate_certs: no
     return_content: yes
+    timeout: 90
   register: redfish_reply
   until: "redfish_reply.status == 204"
   retries: 20

--- a/roles/get_image_hash/tasks/get_image_hash.yml
+++ b/roles/get_image_hash/tasks/get_image_hash.yml
@@ -1,8 +1,16 @@
-- name: "Get {{ item.key }} image hash"
-  shell: "skopeo inspect --authfile {{ local_pull_secret_path }} docker://{{ item.value.image }}:{{ item.value.tag }}"
-  register: result
-  changed_when: false
+- name: "A hash wasn't provided, inspect the image to figure it out"
+  when: not (item.value.hash | default('')) != ''
+  block:
+  - name: "Get {{ item.key }} image hash"
+    shell: "skopeo inspect --authfile {{ local_pull_secret_path }} docker://{{ item.value.image }}:{{ item.value.tag }}"
+    register: result
+    changed_when: false
 
-- name: Update hashes
+  - name: Update hashes
+    set_fact:
+      image_hashes: "{{ image_hashes | default({}) | combine({item.key:  (result.stdout | from_json | json_query('Digest'))}) }}"
+
+- name: "A hash was provided, only update the hash dict"
+  when: (item.value.hash | default('')) != ''
   set_fact:
-    image_hashes: "{{ image_hashes | default({}) | combine({item.key:  (result.stdout | from_json | json_query('Digest'))}) }}"
+    image_hashes: "{{ image_hashes | default({}) | combine({item.key:  item.value.hash}) }}"

--- a/roles/get_image_hash/tasks/main.yml
+++ b/roles/get_image_hash/tasks/main.yml
@@ -5,14 +5,15 @@
   set_fact:
     release_images: "{{ release_images | combine(
         {'release_' + item.short : {
-            'image': release_image_url,
-            'tag': item.long + '-x86_64',
+            'image': item.data.url | default(release_image_url),
+            'tag': item.data.long | default(item.short) + '-x86_64',
+            'hash': item.data.hash | default(''),
           }
         })
       }}"
   vars:
     release_images: {}
-  loop: "{{ ocp_release_versions_map | dict2items(key_name='short', value_name='long') }}"
+  loop: "{{ ocp_release_versions_map | dict2items(key_name='short', value_name='data') }}"
   when: get_release_images | bool
 
 - name: Find hash for images

--- a/roles/get_image_hash/tasks/main.yml
+++ b/roles/get_image_hash/tasks/main.yml
@@ -6,7 +6,7 @@
     release_images: "{{ release_images | combine(
         {'release_' + item.short : {
             'image': item.data.url | default(release_image_url),
-            'tag': item.data.long | default(item.short) + '-x86_64',
+            'tag': item.data is mapping | ternary(item.data.long | default(''), item.data | default('')) + '-x86_64',
             'hash': item.data.hash | default(''),
           }
         })

--- a/roles/populate_mirror_registry/defaults/main.yml
+++ b/roles/populate_mirror_registry/defaults/main.yml
@@ -33,8 +33,10 @@ installer_controller_image:
   local: "{{ local_registry }}/ocpmetal/assisted-installer-controller"
   local_tag: "latest"
 
+release_image_remote: "quay.io/openshift-release-dev/ocp-release"
+
 release_image_item:
-  remote: "quay.io/openshift-release-dev/ocp-release@{{ image_hashes['release_' + openshift_version] }}"
+  remote: "{{ release_image_remote }}@{{ image_hashes['release_' + openshift_version] }}"
   local: "{{ local_registry }}/ocp4/openshift4"
   local_tag: "{{ openshift_full_version }}-x86_64"
 

--- a/roles/populate_mirror_registry/tasks/populate_registry.yml
+++ b/roles/populate_mirror_registry/tasks/populate_registry.yml
@@ -18,7 +18,7 @@
       containers.podman.podman_login_info:
         registry: "registry.redhat.io"
       environment:
-        XDG_RUNTIME_DIR:  "{{ config_file_path }}"
+        XDG_RUNTIME_DIR: "{{ config_file_path }}"
 
     - name: Mirror remote ocpmetal image registry to local
       command: >

--- a/roles/populate_mirror_registry/tasks/prerequisites.yml
+++ b/roles/populate_mirror_registry/tasks/prerequisites.yml
@@ -33,7 +33,7 @@
   block:
     - name: Download oc tarball
       get_url:
-        url: "{{ release_url }}/{{ release_version }}/{{ oc_tar }}"
+        url: "{{ release_url }}/{{ openshift_full_version }}/{{ oc_tar }}"
         dest: "{{ downloads_path }}/"
         force: "{{ force }}"
         backup: yes
@@ -82,7 +82,7 @@
   block:
     - name: Download opm tarball
       get_url:
-        url: "{{ release_url }}/stable-{{ openshift_version }}/{{ opm_tar }}"
+        url: "{{ release_url }}/{{ openshift_full_version }}/{{ opm_tar }}"
         dest: "{{ downloads_path }}/"
         force: "{{ force }}"
         backup: yes

--- a/roles/validate_inventory/tasks/cluster.yml
+++ b/roles/validate_inventory/tasks/cluster.yml
@@ -3,7 +3,7 @@
   assert:
     that:
       - openshift_full_version in supported_ocp_versions
-    fail_msg: "We do not support that version of openshift"
+    fail_msg: "We do not support openshift version {{ openshift_full_version }}"
 
 - name: Assert valid master configuration (HA)
   assert:


### PR DESCRIPTION
Routinely, crucible only supports 1 "blessed" version from each major OCP branch. If you want to support release candidates and development builds, a few changes are needed.
Having these changes plus an inventory that looks something like this:

```yaml
    assisted_service_openshift_versions_defaults:
      "4.7":
        release_version: 4.7.45
        display_name: 4.7.45
        support_level: production
        release_image: "quay.io/openshift-release-dev/ocp-release@sha256:e2c1b0f7057d053045366b58566e81b0b11b92d95f67c8a3d4e8fd5b6e0a7f96"
        rhcos_version: 47.84.202109241831-0
        rhcos_image: "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202109241831-0/x86_64/rhcos-47.84.202109241831-0-live.x86_64.iso"
        rhcos_rootfs: "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202109241831-0/x86_64/rhcos-47.84.202109241831-0-live-rootfs.x86_64.img"
      "4.8":
        release_version: 4.8.36
        display_name: 4.8.36
        support_level: tech-preview
        release_image: "quay.io/openshift-release-dev/ocp-release@sha256:faf1f5ae9636ef79c6027cd1ca68b0a93607f8ccc12e8e537f8f8bc21d7dfb15"
        rhcos_version: 48.84.202109241901-0
        rhcos_image: "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live.x86_64.iso"
        rhcos_rootfs: "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live-rootfs.x86_64.img"
      "4.9":
        release_version: 4.9.0-0.nightly-2021-09-09-145014
        display_name: 4.9.0-0.nightly-2021-09-09-145014
        support_level: dev-preview
        release_image: "quay.io/openshift-release-dev/ocp-release-nightly@sha256:beb878e06dbe123a9711c5f832587670fc135264a452d1c6c498b84896f468a9"
        rhcos_version: 49.84.202107010027-0
        rhcos_image: "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live.x86_64.iso"
        rhcos_rootfs: "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-rootfs.x86_64.img"
    supported_ocp_versions:
      - 4.7.45
      - 4.8.36
      - 4.9.0-0.nightly-2021-09-09-145014
    ocp_release_versions_map_all:
      "4.7":
        long: 4.7.45
        hash: sha256:e2c1b0f7057d053045366b58566e81b0b11b92d95f67c8a3d4e8fd5b6e0a7f96
      "4.8":
        long: 4.8.36
        hash: sha256:faf1f5ae9636ef79c6027cd1ca68b0a93607f8ccc12e8e537f8f8bc21d7dfb15
      "4.9":
        long: 4.9.0-0.nightly-2021-09-09-145014
        hash: sha256:beb878e06dbe123a9711c5f832587670fc135264a452d1c6c498b84896f468a9
        url: quay.io/openshift-release-dev/ocp-release-nightly
    # OpenShift version (shipped defaults are: 4.6.16, 4.7.33, 4.8.14 or 4.9.0)
    openshift_full_version: 4.7.45
    #openshift_full_version: 4.8.36  # candidate
    #openshift_full_version: 4.9.0-0.nightly-2021-09-09-145014  # dev/nightly
    # uncomment for nightly releases
    #release_image_remote: quay.io/openshift-release-dev/ocp-release-nightly
    #release_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview
```

Allows you to test several different types of builds.

I've tried to make it backwards compatible but I bet there are quite a few changes needed, please do review carefully and let me know any questions :smiley: 