### PR TITLE
Naked bridge

### DIFF
--- a/roles/process_nmstate/templates/nmstate.yml.j2
+++ b/roles/process_nmstate/templates/nmstate.yml.j2
@@ -54,11 +54,13 @@ interfaces:
         multicast-snooping: {{ interface.bridge.snooping | default(true) }}
         stp:
           enabled: {{ interface.bridge.stp | default(true) }}
+      {% if interface.bridge.port is defined %}
       port:
         - name: {{ interface.bridge.port.name }}
           stp-hairpin-mode: {{ interface.bridge.port.hairpin | default(false) }}
           stp-path-cost: {{ interface.bridge.port.cost | default(100) }}
           stp-priority: {{ interface.bridge.port.priority | default(32) }}
+      {% endif %}
   {% endif %}
 {% endfor %}
 {% if network_config.routes is defined %}


### PR DESCRIPTION
Minor update to allow fully isolated virt environments which we use for our CI setup.

With this patch we can specify the following in the hosts: -> vm_host1 section.

```yaml
          network_config:
            interfaces:
              - type: linux-bridge
                name: "{{ cluster_name }}-br"
                addresses:
                  ipv4:
                    - ip: "{{ vm_bridge_ip }}"
                      prefix: "{{ machine_network_cidr | ipaddr('prefix') }}"
                bridge:
                  stp: True
```