### PR TITLE
Adding stand alone playbook to register hosts and enable repos.

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -19,7 +19,7 @@ and are nominally put in the order of usage with some exceptions. This may be us
 | `create_cluster.yml`                   | Creates cluster definition in assisted installer                                 | -                     |
 | `generate_discovery_iso.yml`           | Generate descovery iso                                                           | `cluster_id`          |
 | `boot_iso.yml`                         | Reboots nodes to discovery iso                                                   | -                     |
-| `mount_discovery_iso_for_pxe.yml`      |  Mounts discovery iso, generates grub config and syncs files to the TFTP server  | -                     |
+| `mount_discovery_iso_for_pxe.yml`      | Mounts discovery iso, generates grub config and syncs files to the TFTP server   | -                     |
 | `install_cluster.yml`                  | Trigger install of discovered hosts                                              | `cluster_id`          |
 | `monitor_hosts.yml`                    | Monitor hosts for discovery and to become ready                                  | `cluster_id`          |
 | `monitor_cluster.yml`                  | Monitor cluster for installation and initalisation                               | `cluster_id`          |
@@ -31,3 +31,6 @@ and are nominally put in the order of usage with some exceptions. This may be us
 | `boot_disk.yml`                        | Reboots nodes to disk                                                            | -                     |
 | `dell_idrac_soft_reset.yml`            | Runs `racadm racreset` on dell nodes                                             | -                     |
 | `destroy_vms.yml`                      | Destroy VMs and bridge                                                           | -                     |
+| `rhsm_register.yml`                    | Registers hosts with Red Hat Subscription Manager and enables specified repos    | `rhel_release`        |
+|                                        |                                                                                  | `rhsm_pool_ids`       |
+|                                        |                                                                                  | `rhsm_repos`          |

--- a/playbooks/rhsm_register.yml
+++ b/playbooks/rhsm_register.yml
@@ -1,0 +1,44 @@
+---
+- name: Register host with Red Hat Subscription Manager
+  hosts: bastions,services,vm_hosts
+  gather_facts: true
+  vars_prompt:
+    - name: rhsm_username
+      prompt: "RHSM Username"
+      private: no
+    - name: rhsm_password
+      prompt: "RHSM Password"
+      private: yes
+      unsafe: yes
+  vars:
+    rhel_release: 8.5
+    rhsm_pool_ids: []
+    rhsm_repos: []
+    rhsm_usage: "Development/Test"
+    rhsm_role: "Red Hat Enterprise Server"
+    rhsm_sla: "Self-Support"
+  tasks:
+    - name: "Testing vars"
+      ansible.builtin.fail:
+        msg: "The variables rhsm_username and rhsm_password are required."
+      when: ( (rhsm_username | length) > 0 ) and ( (rhsm_password | length) > 0 )
+    - name: "Registering hosts as {{ rhsm_username }}"
+      community.general.redhat_subscription:
+        state: present
+        force_register: yes
+        release: "{{ rhel_release }}"
+        username: "{{ rhsm_username }}"
+        password: "{{ rhsm_password }}"
+        pool_ids: "{{ item }}"
+        syspurpose:
+          usage: "{{ rhsm_usage }}"
+          role: "{{ rhsm_role }}"
+          service_level_agreement: "{{ rhsm_sla }}"
+          sync: yes
+      loop: rhsm_pool_ids
+    - name: Add repositories to host
+      community.general.rhsm_repository:
+        name: "{{ item }}"
+        state: enabled
+        purge: yes
+      loop: rhsm_repos


### PR DESCRIPTION
This playbook is not intended to be used in OCP deployments but a stand alone playbook used to help prepare hosts.