### PR TITLE
Add hash caching and simplify overriding assisted installer images

### DIFF
--- a/docs/v1_to_v2_transition.md
+++ b/docs/v1_to_v2_transition.md
@@ -43,24 +43,20 @@ assisted_service_openshift_versions_defaults:
 becomes two dicts (notice that the value in the new version is a list):
 
 ```yaml
-
-assisted_installer_os_images_defualts:
-  "4.6":
-    - openshift_version: "4.6"
-      cpu_architecture: "x86_64"
-      url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso"
-      rootfs_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img"
-      version: "46.82.202012051820-0"
+os_images:
+  - openshift_version: '4.6'
+    cpu_architecture: x86_64
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img
+    version: 46.82.202012051820-0
   ...
-
-assisted_installer_release_images_defaults: 
-  "4.6":
-    - openshift_version: "4.6"
-      cpu_architecture: "x86_64"
-      url: "quay.io/openshift-release-dev/ocp-release{% if 'release_4.6' in image_hashes %}@{{ image_hashes['release_4.6'] }}{% else %}:4.6.16-x86_64{% endif %}"
-      version: "4.6.16"
+release_images:
+  - openshift_version: '4.6'
+    cpu_architecture: x86_64
+    url: quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64
+    version: 4.6.16
   ...
-``
+```
 
 ## Proxy
 

--- a/roles/display_deployment_plan/tasks/main.yml
+++ b/roles/display_deployment_plan/tasks/main.yml
@@ -29,6 +29,9 @@
           hosts_missing: "<no hosts set>"
           groups_missing: "<no groups set>"
           kubeadmin_vault_password_file_path_missing: "UNDEFINED (This means the kubeadmin credentals will be stored in plain text)"
+
+        cached_image_hash_file_path: "{{ image_hashes_path | default(repo_root_path + '/image_hashes.yml') }}"
+
         # A default error message is assigned to each variable referenced in the deployment plan.
         # This prevents the prompt from not being displayed due to templating errors if a valid
         # inventory file is not provided.
@@ -50,6 +53,9 @@
           is_valid_single_node_openshift_config: "{{ is_valid_single_node_openshift_config | default(messages.value_missing) }}"
           groups_filtered: "{{ groups | difference(groups_to_exclude) }}"
           kubeadmin_vault_password_file_path: "{{ kubeadmin_vault_password_file_path | default(messages.kubeadmin_vault_password_file_path_missing) }}"
+          cached_image_hash_file_path: "{{ cached_image_hash_file_path }}"
+          cached_image_hash_file_exists: "{{ cached_image_hash_file_path is file }}"
+          ignore_cached_image_hash_file: "{{ ignore_cached_image_hashes | default(false) }}"
       register: display_deployment_plan__confirmation
 
     - name: Assert the deployment plan is confirmed

--- a/roles/display_deployment_plan/templates/plan.j2
+++ b/roles/display_deployment_plan/templates/plan.j2
@@ -48,6 +48,20 @@ An OpenShift cluster is about to be deployed. Please double check the provided i
 {% else %}
   {{ messages.groups_missing }}{{ '\n' }}
 {% endfor %}
+
+* Image hash caching
+
+  {{ row_format_str | format('Cached image hash file path', inventory.cached_image_hash_file_path)}}
+  {{ row_format_str | format('Cached image hash file exists', inventory.cached_image_hash_file_exists)}}
+  {{ row_format_str | format('Ignoring cached image hash file', inventory.ignore_cached_image_hash_file)}}
+
+  {% if  inventory.cached_image_hash_file_exists and not inventory.ignore_cached_image_hash_file %}
+  NOTE: If you have changed any tags for images, the hash will NOT be updated unless you remove the
+        entry from (or remove the entire file)
+        {{ inventory.cached_image_hash_file_path }}
+        or set ignore_cached_image_hashes to True.
+  {% endif %}
+
 ---
 
 Are you sure you want to proceed with the deployment using this inventory configuration?

--- a/roles/get_image_hash/defaults/main.yml
+++ b/roles/get_image_hash/defaults/main.yml
@@ -2,34 +2,95 @@ ai_version: v2.1.1
 controller_tag: "{{ ai_version }}"
 installer_agent_tag: "{{ ai_version }}"
 installer_tag: "{{ ai_version }}"
-
-ocp_release_versions_map_all:
-  '4.6': 4.6.16
-  '4.7': 4.7.33
-  '4.8': 4.8.14
-  '4.9': 4.9.11
-  '4.10': 4.10.10
+assisted_service_tag: "{{ ai_version }}"
+assisted_service_gui_tag: "{{ ai_version }}"
+assisted_service_image_service_tag: "{{ ai_version }}"
 
 get_release_images: true
 get_all_release_versions: false
 
-ocp_release_versions_map: "{{ get_all_release_versions | ternary(ocp_release_versions_map_all, {(openshift_version | string): ocp_release_versions_map_all[openshift_version | string]}) }}"
-
-release_image_url: "quay.io/openshift-release-dev/ocp-release"
-
-assisted_installer_images:
-  controller:
-    image: quay.io/edge-infrastructure/assisted-installer-controller
-    tag: "{{ controller_tag }}"
-  installer_agent:
-    image: quay.io/edge-infrastructure/assisted-installer-agent
-    tag: "{{ installer_agent_tag }}"
-  installer:
-    image: quay.io/edge-infrastructure/assisted-installer
-    tag: "{{ installer_tag }}"
-
-images_to_get_hash_for: "{{ assisted_installer_images | combine(release_images | default({})) }}"
+images_to_get_hash_for: "{{ assisted_installer_images | combine(processed_release_images | default({})) }}"
 
 destination_hosts:
   - registry_host
   - assisted_installer
+
+image_hashes_path: "{{ repo_root_path }}/image_hashes.yml"
+ignore_cached_image_hashes: false
+image_hashes: {}
+
+os_images:
+  - openshift_version: '4.6'
+    cpu_architecture: x86_64
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img
+    version: 46.82.202012051820-0
+  - openshift_version: '4.7'
+    cpu_architecture: x86_64
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-4.7.33-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-live-rootfs.x86_64.img
+    version: 47.84.202109241831-0
+  - openshift_version: '4.8'
+    cpu_architecture: x86_64
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-live-rootfs.x86_64.img
+    version: 48.84.202109241901-0
+  - openshift_version: '4.9'
+    cpu_architecture: x86_64
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-live-rootfs.x86_64.img
+    version: 49.84.202110081407-0
+  - openshift_version: '4.10'
+    cpu_architecture: x86_64
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-x86_64-live-rootfs.x86_64.img
+    version: 410.84.202201251210-0
+  - openshift_version: '4.10'
+    cpu_architecture: arm64
+    url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-aarch64-live.aarch64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-aarch64-live-rootfs.aarch64.img
+    version: 410.84.202201251210-0
+
+release_images:
+  - openshift_version: '4.6'
+    cpu_architecture: x86_64
+    url: quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64
+    version: 4.6.16
+  - openshift_version: '4.7'
+    cpu_architecture: x86_64
+    url: quay.io/openshift-release-dev/ocp-release:4.7.49-x86_64
+    version: 4.7.49
+  - openshift_version: '4.8'
+    cpu_architecture: x86_64
+    url: quay.io/openshift-release-dev/ocp-release:4.8.37-x86_64
+    version: 4.8.37
+  - openshift_version: '4.9'
+    cpu_architecture: x86_64
+    url: quay.io/openshift-release-dev/ocp-release:4.9.29-x86_64
+    version: 4.9.29
+  - openshift_version: '4.10'
+    cpu_architecture: x86_64
+    url: quay.io/openshift-release-dev/ocp-release:4.10.10-x86_64
+    version: 4.10.10
+    default: true
+  - openshift_version: '4.10'
+    cpu_architecture: arm64
+    url: quay.io/openshift-release-dev/ocp-release:4.10.10-aarch64
+    version: 4.10.10
+
+assisted_service_image_repo_url: quay.io/edge-infrastructure
+
+assisted_installer_images:
+  controller:
+    url: "{{ assisted_service_image_repo_url }}/assisted-installer-controller:{{ controller_tag }}"
+  installer_agent:
+    url: "{{ assisted_service_image_repo_url }}/assisted-installer-agent:{{ installer_agent_tag }}"
+  installer:
+    url: "{{ assisted_service_image_repo_url }}/assisted-installer:{{ installer_tag }}"
+  service:
+    url: "{{ assisted_service_image_repo_url }}/assisted-service:{{ assisted_service_tag }}"
+  gui:
+    url: "{{ assisted_service_image_repo_url }}/assisted-installer-ui:{{ assisted_service_gui_tag }}"
+  image_service:
+    url: "{{ assisted_service_image_repo_url }}/assisted-image-service:{{ assisted_service_image_service_tag }}"
+  

--- a/roles/get_image_hash/tasks/get_image_hash.yml
+++ b/roles/get_image_hash/tasks/get_image_hash.yml
@@ -2,15 +2,15 @@
   when: not (item.value.hash | default('')) != ''
   block:
   - name: "Get {{ item.key }} image hash"
-    shell: "skopeo inspect --authfile {{ local_pull_secret_path }} docker://{{ item.value.image }}:{{ item.value.tag }}"
+    shell: "skopeo inspect --authfile {{ local_pull_secret_path }} docker://{{ item.value.url }}"
     register: result
     changed_when: false
 
   - name: Update hashes
     set_fact:
-      image_hashes: "{{ image_hashes | default({}) | combine({item.key:  (result.stdout | from_json | json_query('Digest'))}) }}"
+      image_hashes: "{{ image_hashes | combine({item.key:  (result.stdout | from_json | json_query('Digest'))}) }}"
 
 - name: "A hash was provided, only update the hash dict"
   when: (item.value.hash | default('')) != ''
   set_fact:
-    image_hashes: "{{ image_hashes | default({}) | combine({item.key:  item.value.hash}) }}"
+    image_hashes: "{{ image_hashes | combine({item.key:  item.value.hash}) }}"

--- a/roles/get_image_hash/tasks/main.yml
+++ b/roles/get_image_hash/tasks/main.yml
@@ -58,11 +58,11 @@
 
 - name: Create image cache file
   copy:
-    content: "{{ image_hashes | to_yaml }}"
+    content: "{{ image_hashes | to_nice_yaml }}"
     dest: "{{ image_hashes_path }}"
     mode: 0660
   delegate_to: localhost
-  when: image_hashes_path is file
+  when: image_hashes_path is not file
 
 - name: Update release_images with hashes
   when: get_release_images | bool

--- a/roles/get_image_hash/tasks/main.yml
+++ b/roles/get_image_hash/tasks/main.yml
@@ -1,19 +1,50 @@
 - name: check skopeo is installed
   shell: /usr/bin/skopeo --version
 
+- name: Filter images 
+  when: get_release_images | bool
+  block: 
+    - name: Filter os images
+      set_fact:
+        os_images: "{{ os_images | json_query(os_filter) }}"
+      vars:
+        os_filter: "[?(openshift_version == '{{ openshift_version }}')]"
+      when: (not get_all_release_versions) | bool
+    
+    - debug: # noqa unnamed-task
+        var: os_images
+        verbosity: 1
+
+    - name: Filter release images
+      set_fact:
+        release_images: "{{ release_images | json_query(release_filter) }}"
+      vars:
+        release_filter: "[?(version == '{{ openshift_full_version }}')]"
+      when: (not get_all_release_versions) | bool
+   
+    - debug: # noqa unnamed-task
+        var: release_images
+        verbosity: 1
+        
+- name: Get cached images
+  include_vars:
+    file: "{{ image_hashes_path }}"
+    name: image_hashes
+  when: image_hashes_path is file and ignore_cached_image_hashes | bool
+  delegate_to: localhost
+
 - name: Build release_images entries
   set_fact:
-    release_images: "{{ release_images | combine(
-        {'release_' + item.short : {
-            'image': item.data.url | default(release_image_url),
-            'tag': item.data is mapping | ternary(item.data.long | default(''), item.data | default('')) + '-x86_64',
-            'hash': item.data.hash | default(''),
+    processed_release_images: "{{ processed_release_images | combine(
+        { ('release_' + item.version + '_' + item.cpu_architecture) : {
+            'url': item.url,
+            'hash': item.hash | default(''),
           }
         })
       }}"
   vars:
-    release_images: {}
-  loop: "{{ ocp_release_versions_map | dict2items(key_name='short', value_name='data') }}"
+    processed_release_images: {}
+  loop: "{{ release_images }}"
   when: get_release_images | bool
 
 - name: Find hash for images
@@ -22,7 +53,49 @@
     apply:
       tags:
         - install
+  when: item.key not in image_hashes
   loop: "{{ images_to_get_hash_for | dict2items }}"
+
+- name: Create image cache file
+  copy:
+    content: "{{ image_hashes | to_yaml }}"
+    dest: "{{ image_hashes_path }}"
+    mode: 0660
+  delegate_to: localhost
+  when: image_hashes_path is file
+
+- name: Update release_images with hashes
+  when: get_release_images | bool
+  block:
+    - name: Update released items
+      vars: 
+        updated_release_images: []
+      set_fact:
+        updated_release_images: "{{ updated_release_images + [item | combine({'url': item.url.split(':')[0] + '@' + image_hashes['release_' + item.version + '_' + item.cpu_architecture]  })] }}"
+      when: 
+        - (':' in item.url)
+        - ('release_' + item.version + '_' + item.cpu_architecture) in image_hashes
+      loop: "{{ release_images }}"
+
+    - name: Redefine release images to 
+      set_fact:
+        release_images: "{{ updated_release_images }}"
+      when: updated_release_images is defined
+   
+    - debug: # noqa unnamed-task
+        var: os_images
+        verbosity: 1
+    
+    - debug: # noqa unnamed-task
+        var: release_images
+        verbosity: 1
+
+    - name: Set values on assiste host
+      set_fact:
+        assisted_installer_os_images: "{{ os_images }}"
+        assisted_installer_release_images: "{{ release_images }}"
+      delegate_to: "assisted_installer"
+      delegate_facts: true
 
 - name: "Set image hashes in {{ item }}"
   set_fact:
@@ -30,10 +103,3 @@
   delegate_to: "{{ item }}"
   delegate_facts: true
   loop: "{{ destination_hosts }}"
-
-- name: "Set ocp_release_versions in assisted_installer host"
-  set_fact:
-    ocp_release_versions: "{{ ocp_release_versions_map.keys() | list }}"
-  when: get_release_images | bool
-  delegate_to: "assisted_installer"
-  delegate_facts: true

--- a/roles/setup_assisted_installer/defaults/main.yml
+++ b/roles/setup_assisted_installer/defaults/main.yml
@@ -1,95 +1,16 @@
-ai_version: v2.1.1
-assisted_service_tag: "{{ ai_version }}"
-assisted_service_gui_tag: "{{ ai_version }}"
-assisted_service_image_service_tag: "{{ ai_version }}"
-
-# For older version you can use "ocpmetal"
 assisted_service_image_repo: "edge-infrastructure"
 assisted_service_image_repo_url: "quay.io/{{ assisted_service_image_repo }}"
 
-# Tagged images 
-assisted_service_image: "{{ assisted_service_image_repo_url }}/assisted-service:{{ assisted_service_tag }}"
-assisted_service_gui_image: "{{ assisted_service_image_repo_url }}/assisted-installer-ui:{{ assisted_service_gui_tag }}"
-assisted_service_image_service_image: "{{ assisted_service_image_repo_url }}/assisted-image-service:{{ assisted_service_image_service_tag }}"
+assisted_service_image: "{{ assisted_service_image_repo_url }}/assisted-service@{{ image_hashes.service }}"
+assisted_service_gui_image: "{{ assisted_service_image_repo_url }}/assisted-installer-ui@{{ image_hashes.gui }}"
+assisted_service_image_service_image: "{{ assisted_service_image_repo_url }}/assisted-image-service@{{ image_hashes.image_service }}"
 
-# Digest images
 assisted_service_controller_image: "{{ assisted_service_image_repo_url }}/assisted-installer-controller@{{ image_hashes.controller }}"
 assisted_service_installer_agent_image: "{{ assisted_service_image_repo_url }}/assisted-installer-agent@{{ image_hashes.installer_agent }}"
 assisted_service_installer_image: "{{ assisted_service_image_repo_url }}/assisted-installer@{{ image_hashes.installer }}"
 assisted_postgres_image: quay.io/centos7/postgresql-12-centos7:latest
-
 assisted_installer_dir: /opt/assisted-installer
-
-# Don't forget to update the sample inventory and supported versions
-assisted_installer_os_images_defualts:
-  "4.6":
-    - openshift_version: "4.6"
-      cpu_architecture: "x86_64"
-      url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso"
-      rootfs_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img"
-      version: "46.82.202012051820-0"
-  "4.7":
-    - openshift_version: "4.7"
-      cpu_architecture: "x86_64"
-      url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-4.7.33-x86_64-live.x86_64.iso"
-      rootfs_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-live-rootfs.x86_64.img"
-      version: "47.84.202109241831-0"
-  "4.8":
-    - openshift_version: "4.8"
-      cpu_architecture: "x86_64"
-      url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso"
-      rootfs_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-live-rootfs.x86_64.img"
-      version: "48.84.202109241901-0"
-  "4.9":
-    - openshift_version: "4.9"
-      cpu_architecture: "x86_64"
-      url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso"
-      rootfs_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-live-rootfs.x86_64.img"
-      version: "49.84.202110081407-0"
-  # - openshift_version: "4.9"
-  #   cpu_architecture: "arm64"
-  #   url: "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-aarch64-live.aarch64.iso"
-  #   rootfs_url: "https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-aarch64-live-rootfs.aarch64.img"
-  #   version: "49.84.202110080947-0"
-  "4.10":
-    - openshift_version: "4.10"
-      cpu_architecture: "x86_64"
-      url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-x86_64-live.x86_64.iso"
-      rootfs_url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-x86_64-live-rootfs.x86_64.img"
-      version: "410.84.202201251210-0"
-
-# Don't forget to update the sample inventory and supported versions
-assisted_installer_release_images_defaults: 
-  "4.6":
-    - openshift_version: "4.6"
-      cpu_architecture: "x86_64"
-      url: "quay.io/openshift-release-dev/ocp-release{% if 'release_4.6' in image_hashes %}@{{ image_hashes['release_4.6'] }}{% else %}:4.6.16-x86_64{% endif %}"
-      version: "4.6.16"
-  "4.7":
-    - openshift_version: "4.7"
-      cpu_architecture: "x86_64"
-      url: "quay.io/openshift-release-dev/ocp-release{% if 'release_4.7' in image_hashes %}@{{ image_hashes['release_4.7'] }}{% else %}:4.7.33-x86_64{% endif %}"
-      version: "4.7.33"
-  "4.8":
-    - openshift_version: "4.8"
-      cpu_architecture: "x86_64"
-      url: "quay.io/openshift-release-dev/ocp-release{% if 'release_4.8' in image_hashes %}@{{ image_hashes['release_4.8'] }}{% else %}:4.8.14-x86_64{% endif %}"
-      version: "4.8.14"
-  "4.9":
-    - openshift_version: "4.9"
-      cpu_architecture: "x86_64"
-      url: "quay.io/openshift-release-dev/ocp-release{% if 'release_4.9' in image_hashes %}@{{ image_hashes['release_4.9'] }}{% else %}:4.9.11-x86_64{% endif %}"
-      version: "4.9.11"
-      default: true
-    # - openshift_version: "4.9"
-    #   cpu_architecture: "arm64"
-    #   url: "quay.io/openshift-release-dev/ocp-release:4.9.17-aarch64"
-    #   version: "4.9.17"
-  "4.10":
-    - openshift_version: "4.10"
-      cpu_architecture: "x86_64"
-      url: "quay.io/openshift-release-dev/ocp-release{% if 'release_4.10' in image_hashes %}@{{ image_hashes['release_4.10'] }}{% else %}:4.10.10-x86_64{% endif %}"
-      version: "4.10.10"
+assisted_installer_data_dir: "{{ assisted_installer_dir }}/data"
 
 assisted_installer_hardware_validation:
 - version: default

--- a/roles/setup_assisted_installer/tasks/main.yml
+++ b/roles/setup_assisted_installer/tasks/main.yml
@@ -36,19 +36,6 @@
   
       when: use_local_mirror_registry  | bool
 
-- name: Preconfigure AI requriements
-  become: True
-  block:
-    - name: "Build assisted_service_openshift_versions ({{ item }})"
-      vars:
-        assisted_service_openshift_versions: {}
-        assisted_installer_os_images: []
-        assisted_installer_release_images: []
-      set_fact:
-        assisted_installer_os_images: "{{ assisted_installer_os_images + assisted_installer_os_images_defualts[item] }}"
-        assisted_installer_release_images: "{{ assisted_installer_release_images + assisted_installer_release_images_defaults[item] }}"
-      loop: "{{ ocp_release_versions }}"
-
     - name: Open ports zone internal and public, for firewalld
       firewalld:
         port: "{{ item.1 }}/tcp"
@@ -65,18 +52,18 @@
         state: directory
       with_items:
         - "{{ assisted_installer_dir }}"
-        - "{{ assisted_installer_dir }}/data"
+        - "{{ assisted_installer_data_dir }}"
 
     - name: Create directory for assisted-installer database
       file:
-        path: "{{ assisted_installer_dir }}/data/postgresql"
+        path: "{{ assisted_installer_data_dir }}/postgresql"
         mode: 0775
         state: directory
         recurse: true
     
     - name: Create directory for assisted-installer images 
       file:
-        path: "{{ assisted_installer_dir }}/data/image_service"
+        path: "{{ assisted_installer_data_dir }}/image_service"
         mode: 0775
         state: directory
         recurse: true

--- a/roles/setup_assisted_installer/templates/pod.yml.j2
+++ b/roles/setup_assisted_installer/templates/pod.yml.j2
@@ -43,11 +43,11 @@ spec:
   volumes:
     - name: db-volume
       hostPath:
-        path:  "{{ assisted_installer_dir }}/data/postgresql"
+        path:  "{{ assisted_installer_data_dir }}/postgresql"
         type: Directory
     - name: image-data-volume
       hostPath:
-        path:  "{{ assisted_installer_dir }}/data/image_service"
+        path:  "{{ assisted_installer_data_dir }}/image_service"
         type: Directory
   restartPolicy: OnFailure
   {% if (dns_servers | length) > 0 %}


### PR DESCRIPTION
Hashes are now saved to a file in the repo root. If the
image key is already in the image_hashes saved we will not try
to get a new one. If you change version you expect to get you
may want to remove the value from the file or the file completely.
There is also a flag `ignore_cached_image_hashes` which will
ignore any save values and write a new file.

It is now much simpler to override the values in the os_images and
release_images as the format is now the same as assisted installer
expects. And there is no need to override as mean values as previous
just override os_images (if required), release_images and
supported_ocp_versions.