### PR TITLE
fix for 4.10

### DIFF
--- a/roles/populate_mirror_registry/defaults/main.yml
+++ b/roles/populate_mirror_registry/defaults/main.yml
@@ -44,7 +44,7 @@ installer_controller_image:
 release_image_remote: "quay.io/openshift-release-dev/ocp-release"
 
 release_image_item:
-  remote: "{{ release_image_remote }}@{{ image_hashes['release_' + (openshift_version | string)] }}"
+  remote: "{{ release_image_remote }}@{{ image_hashes['release_' + (openshift_full_version | string) + '_x86_64'] }}"
   local: "{{ local_registry }}/ocp4/openshift4"
   local_tag: "{{ openshift_full_version }}-x86_64"
 


### PR DESCRIPTION
Fix for:

```
task path:/crucible/roles/populate_mirror_registry/tasks/populate_registry.yml:36
Monday 20 June 2022  06:03:56 -0400 (0:00:03.883)       0:03:04.256 ***********
fatal: [registry_host]: FAILED! =>
  msg: |-
    The task includes an option with an undefined variable. The error was: {'remote': "{{ release_image_remote }}@{{ image_hashes['release_' + (openshift_version | s
tring)] }}", 'local': '{{ local_registry }}/ocp4/openshift4', 'local_tag': '{{ openshift_full_version }}-x86_64'}: 'dict object' has no attribute 'release_4.10'
 
    The error appears to be in '/crucible/roles/populate_mirror_registry/tasks/populate_registry.yml': line 36, column 7, but may
    be elsewhere in the file depending on the exact syntax problem.
 
    The offending line appears to be:
 
 
        - name: Mirror remote registry to local
          ^ here

```