### PR TITLE
Do regex to check mac is in linux format

### DIFF
--- a/roles/validate_inventory/tasks/cluster.yml
+++ b/roles/validate_inventory/tasks/cluster.yml
@@ -50,6 +50,17 @@
     fail_msg: "Node {{ item }} has an incorrectly formatted var"
   loop: "{{ groups['nodes'] }}"
 
+- name: Assert mac has linux format
+  assert:
+    that:
+      - ( hostvars[item]['mac'] | string | regex_search('^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$')) is not none
+    quiet: true
+    fail_msg: |-
+      The mac address for node {{ item }} needs to be in linx format XX:XX:XX:XX:XX:XX 
+      Make sure to wrap it quotes to make sure it is not being mangled
+      Current value: {{ hostvars[item]['mac'] }}
+  loop: "{{ groups['nodes'] }}"
+
 - name: Assert that all values of 'vendor' are supported
   assert:
     that:


### PR DESCRIPTION
If using an all digit mac address even when using the linux format ansible will
cast that into a mangled integer. Added an assert to alert the user of this
is happening and tell them to wrap the mac in quotes