### PR TITLE
Fix error when fetching missing inventory

### DIFF
--- a/roles/patch_host_config/tasks/main.yml
+++ b/roles/patch_host_config/tasks/main.yml
@@ -15,6 +15,11 @@
 
 - name: Identify the discovered host {{ discovered_host.id }}
   set_fact:
+    host: "{{ host.json }}"
+  when: discovered_host.inventory is not defined
+
+- name: Identify the discovered host {{ discovered_host.id }}
+  set_fact:
     host: "{{ discovered_host }}"
   when: discovered_host.inventory is defined
 


### PR DESCRIPTION
The task above (`Wait for up to 10 minutes for node discovery`) waits for the inventory however it will incorrectly set host to tasks result instead of the contents of the reply which is in the json attribute. 