### PR TITLE
Don't process bmc_dns_records if not defined

### DIFF
--- a/roles/insert_dns_records/tasks/main.yml
+++ b/roles/insert_dns_records/tasks/main.yml
@@ -37,6 +37,8 @@
   delegate_to: "{{ item.host }}"
   delegate_facts: true
   loop: "{{ bmc_dns_records | dict2items(key_name='host', value_name='data') }}"
+  when:
+    - bmc_dns_records is defined
 
 - name: Get bastions, services (not including registry) when it ansible_host is an IP address
   include_tasks: create_host_entry.yml


### PR DESCRIPTION
Pretty self explanatory, If bmc_dns_records isn't defined then don't try and process them.