### PR TITLE
Refresh versions and RHCOS images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 
 This repository contains playbooks for automating the creation of an OpenShift Container Platform cluster on premise using the Developer Preview version of the OpenShift Assisted Installer. The playbooks require only minimal infrastructure configuration and do not require any pre-existing cluster. Virtual and Bare Metal deployments have been tested in restricted network environments where nodes do not have direct access to the Internet.
 
-These playbooks assume a prior working knowledge of [Ansible](http://www.ansible.com). They are intended to be run from a `bastion` host, running a subscribed installation of RHEL 8.4, inside the target environment. Pre-requisites can be installed manually or automatically, as appropriate.
+These playbooks assume a prior working knowledge of [Ansible](http://www.ansible.com). They are intended to be run from a `bastion` host, running a subscribed installation of Red Hat Enterprise Linux (RHEL) 8.6, inside the target environment. Pre-requisites can be installed manually or automatically, as appropriate.
 
 See [how the playbooks are intended to be run](docs/connecting_to_hosts.md) and understand [what steps the playbooks take](docs/pipeline_into_the_details.md).
 
@@ -23,7 +23,7 @@ See [how the playbooks are intended to be run](docs/connecting_to_hosts.md) and 
 ## Software Versions Supported
 Crucible targets versions of Python and Ansible that ship with RHEL. At the moment the supported versions are:
 
-- RHEL 8.3
+- RHEL 8.6
 - Python 3.6.8
 - Ansible 2.9.27
 
@@ -33,6 +33,9 @@ Crucible targets versions of Python and Ansible that ship with RHEL. At the mome
 - 4.6
 - 4.7
 - 4.8
+- 4.9
+- 4.10
+
 
 
 ## Assisted Installer versions Tested
@@ -51,12 +54,12 @@ Requires the following to be installed on the deployment host:
 - [jmespath](https://github.com/jmespath)
 - [skopeo](https://github.com/containers/skopeo)
 - [podman](https://github.com/containers/podman/)
-- [kubectl + oc](https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html)
+- [kubectl + oc](https://docs.openshift.com/container-platform/4.10/cli_reference/openshift_cli/getting-started-cli.html)
 - [pyghmi](https://pypi.org/project/pyghmi/) #For PXE deployment
 - [ipmitool](https://github.com/ipmitool/ipmitool) #For PXE deployment
 
 
-**Important Note** The `openshift-clients` package is part of the [Red Hat OpenShift Container Platform Subscription](https://access.redhat.com/downloads/content/290/). The repo [must be activated on the bastion host](https://docs.openshift.com/container-platform/4.9/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli-rpm_cli-developer-commands) before the dependency installation. It is used for the post-installation cluster validation steps.
+**Important Note** The `openshift-clients` package is part of the [Red Hat OpenShift Container Platform Subscription](https://access.redhat.com/downloads/content/290/). The repo [must be activated on the bastion host](https://docs.openshift.com/container-platform/4.10/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli-rpm_cli-developer-commands) before the dependency installation. It is used for the post-installation cluster validation steps.
 
 
 ```bash

--- a/inventory.yml.sample
+++ b/inventory.yml.sample
@@ -12,8 +12,8 @@ all:
     cluster_name: clustername
     base_dns_domain: example.lab
 
-    # OpenShift version (4.6.16, 4.7.33, 4.8.14 or 4.9.11)
-    openshift_full_version: 4.6.16
+    # OpenShift version (4.6.16, 4.7.52, 4.8.43, 4.9.40, or 4.10.16)
+    openshift_full_version: 4.10.16
 
     # Virtual IP addresses used to access the resulting OpenShift cluster
     api_vip: 10.60.0.96 # the IP address to be used for api.clustername.example.lab and api-int.clustername.example.lab

--- a/roles/get_image_hash/defaults/main.yml
+++ b/roles/get_image_hash/defaults/main.yml
@@ -37,19 +37,19 @@ os_images:
     version: 48.84.202109241901-0
   - openshift_version: '4.9'
     cpu_architecture: x86_64
-    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-live-rootfs.x86_64.img
-    version: 49.84.202110081407-0
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-4.9.40-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-live-rootfs.x86_64.img
+    version: 49.84.202206171736-0
   - openshift_version: '4.10'
     cpu_architecture: x86_64
-    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-x86_64-live.x86_64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-x86_64-live-rootfs.x86_64.img
-    version: 410.84.202201251210-0
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live-rootfs.x86_64.img
+    version: 410.84.202205191234-0
   - openshift_version: '4.10'
     cpu_architecture: arm64
-    url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-aarch64-live.aarch64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.3/rhcos-4.10.3-aarch64-live-rootfs.aarch64.img
-    version: 410.84.202201251210-0
+    url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-aarch64-live.aarch64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-aarch64-live-rootfs.aarch64.img
+    version: 410.84.202205191234-0
 
 release_images:
   - openshift_version: '4.6'
@@ -58,25 +58,25 @@ release_images:
     version: 4.6.16
   - openshift_version: '4.7'
     cpu_architecture: x86_64
-    url: quay.io/openshift-release-dev/ocp-release:4.7.49-x86_64
-    version: 4.7.49
+    url: quay.io/openshift-release-dev/ocp-release:4.7.52-x86_64
+    version: 4.7.52
   - openshift_version: '4.8'
     cpu_architecture: x86_64
-    url: quay.io/openshift-release-dev/ocp-release:4.8.37-x86_64
-    version: 4.8.37
+    url: quay.io/openshift-release-dev/ocp-release:4.8.43-x86_64
+    version: 4.8.43
   - openshift_version: '4.9'
     cpu_architecture: x86_64
-    url: quay.io/openshift-release-dev/ocp-release:4.9.29-x86_64
-    version: 4.9.29
+    url: quay.io/openshift-release-dev/ocp-release:4.9.40-x86_64
+    version: 4.9.40
   - openshift_version: '4.10'
     cpu_architecture: x86_64
-    url: quay.io/openshift-release-dev/ocp-release:4.10.10-x86_64
-    version: 4.10.10
+    url: quay.io/openshift-release-dev/ocp-release:4.10.16-x86_64
+    version: 4.10.16
     default: true
   - openshift_version: '4.10'
     cpu_architecture: arm64
-    url: quay.io/openshift-release-dev/ocp-release:4.10.10-aarch64
-    version: 4.10.10
+    url: quay.io/openshift-release-dev/ocp-release:4.10.16-aarch64
+    version: 4.10.16
 
 assisted_service_image_repo_url: quay.io/edge-infrastructure
 

--- a/roles/validate_inventory/defaults/main.yml
+++ b/roles/validate_inventory/defaults/main.yml
@@ -22,9 +22,9 @@ ai_version_number: "{{ ai_version | regex_replace('v(\\d+\\.\\d+\\.\\d+)', '\\1'
 
 supported_ocp_versions:
 - 4.6.16
-- 4.7.49
-- 4.8.37
-- 4.9.29
-- 4.10.10
+- 4.7.52
+- 4.8.43
+- 4.9.40
+- 4.10.16
 
 single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"

--- a/tests/validate_inventory/templates/all_reachable.yml
+++ b/tests/validate_inventory/templates/all_reachable.yml
@@ -2,7 +2,7 @@ all:
   vars:
     setup_ntp_service: false
     ntp_server: localhost
-    openshift_full_version: 4.6.16
+    openshift_full_version: 4.10.16
 
   children:
     bastions:

--- a/tests/validate_inventory/templates/all_unreachable.yml
+++ b/tests/validate_inventory/templates/all_unreachable.yml
@@ -2,7 +2,7 @@ all:
   vars:
     setup_ntp_service: false
     ntp_server: 240.0.0.0
-    openshift_full_version: 4.6.16
+    openshift_full_version: 4.10.16
 
   children:
     bastions:

--- a/tests/validate_inventory/templates/invalid_empty_var.yml
+++ b/tests/validate_inventory/templates/invalid_empty_var.yml
@@ -1,6 +1,6 @@
 all:
   vars:
-    openshift_full_version: 4.6.16
+    openshift_full_version: 4.10.16
   children:
     nodes:
       vars:

--- a/tests/validate_inventory/templates/invalid_missing_var.yml
+++ b/tests/validate_inventory/templates/invalid_missing_var.yml
@@ -1,6 +1,6 @@
 all:
   vars:
-    openshift_full_version: 4.6.16
+    openshift_full_version: 4.10.16
   children:
     nodes:
       vars:

--- a/tests/validate_inventory/templates/ntp_unreachable.yml
+++ b/tests/validate_inventory/templates/ntp_unreachable.yml
@@ -2,7 +2,7 @@ all:
   vars:
     setup_ntp_service: false
     ntp_server: 240.0.0.0
-    openshift_full_version: 4.6.16
+    openshift_full_version: 4.10.16
 
   children:
     bastions:

--- a/tests/validate_inventory/templates/test_inv.yml.j2
+++ b/tests/validate_inventory/templates/test_inv.yml.j2
@@ -3,7 +3,7 @@ all:
     {% if item.template.day2_discovery_iso_name is defined %}
     day2_discovery_iso_name: {{ item.template.day2_discovery_iso_name }}
     {% endif %}
-    openshift_full_version: {{ item.template.openshift_full_version | default('4.6.16') }}
+    openshift_full_version: {{ item.template.openshift_full_version | default('4.10.16') }}
     setup_dns_service: {{ item.template.setup_dns_service | default(False)}}
     {% if item.template.allow_custom_vendor is defined %}
     allow_custom_vendor: {{ item.template.allow_custom_vendor }}

--- a/tests/validate_inventory/templates/test_inv_secrets.yml.j2
+++ b/tests/validate_inventory/templates/test_inv_secrets.yml.j2
@@ -1,6 +1,6 @@
 all:
   vars:
-    openshift_full_version: {{ item.template.openshift_full_version | default('4.6.16') }}
+    openshift_full_version: {{ item.template.openshift_full_version | default('4.10.16') }}
   children:
     services:
       hosts:


### PR DESCRIPTION
This PR:

(1) refreshes RHCOS base images used for both the 4.9 and 4.10 releases to a more recent version hosted on the OpenShift mirror site (mirror.openshift.com).  These represent 6 months of RHEL fixes and should be used as a base vs their older counterparts, as known problems have been observed in lab deployments with HA topologies.
(2) refreshes supported OpenShift versions to releases that contain rebases for `ice` and `iavf` 
drivers.  Customers and partners should also try to stay current with enhancements and security fixes present in these newer versions.
(3) update documentation to reflect support for both OpenShift 4.9 and 4.10, as well as links to public OpenShift documentation for the 4.10 release.
