### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 
 This repository contains playbooks for automating the creation of an OpenShift Container Platform cluster on premise using the Developer Preview version of the OpenShift Assisted Installer. The playbooks require only minimal infrastructure configuration and do not require any pre-existing cluster. Virtual and Bare Metal deployments have been tested in restricted network environments where nodes do not have direct access to the Internet.
 
-These playbooks assume a prior working knowledge of [Ansible](http://www.ansible.com). They are intended to be run from a `bastion` host, running a subscribed installation of RHEL 8.4, inside the target environment. Pre-requisites can be installed manually or automatically, as appropriate.
+These playbooks assume a prior working knowledge of [Ansible](http://www.ansible.com). They are intended to be run from a `bastion` host, running a subscribed installation of RHEL 8.6, inside the target environment. Pre-requisites can be installed manually or automatically, as appropriate.
 
 See [how the playbooks are intended to be run](docs/connecting_to_hosts.md) and understand [what steps the playbooks take](docs/pipeline_into_the_details.md).
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [how the playbooks are intended to be run](docs/connecting_to_hosts.md) and 
 ## Software Versions Supported
 Crucible targets versions of Python and Ansible that ship with RHEL. At the moment the supported versions are:
 
-- RHEL 8.3
+- RHEL 8.6
 - Python 3.6.8
 - Ansible 2.9.27
 


### PR DESCRIPTION
Let's update this to 8.6 - AI v2.1 and later won't install on 8.4 due to issues with the older version of podman.
On 8.4, the assisted-installer-db container fails to come up with the following logged:
[root@5gc-bstn01 opt]# podman logs assisted-installer-db
initdb: error: cannot be run as root
Please log in (using, e.g., "su") as the (unprivileged) user that will
own the server process.
initdb: error: cannot be run as root
Please log in (using, e.g., "su") as the (unprivileged) user that will
own the server process.
initdb: error: cannot be run as root
Please log in (using, e.g., "su") as the (unprivileged) user that will
own the server process.
initdb: error: cannot be run as root
Please log in (using, e.g., "su") as the (unprivileged) user that will