### PR TITLE
Work around for network manager ordering race condition 

### DIFF
--- a/roles/generate_discovery_iso/defaults/main.yml
+++ b/roles/generate_discovery_iso/defaults/main.yml
@@ -31,3 +31,5 @@ ai_version_number: "{{ ai_version | regex_replace('v(\\d+\\.\\d+\\.\\d+)', '\\1'
 http_proxy: ""
 https_proxy: ""
 no_proxy: ""
+
+use_hostname_workaround: false

--- a/roles/generate_discovery_iso/tasks/main.yml
+++ b/roles/generate_discovery_iso/tasks/main.yml
@@ -21,7 +21,12 @@
 
 - name: Load patch for discovery ignition
   set_fact:
-    patch_discovery_ignition: "{{ lookup('template', 'patch-discovery-ignition.j2') }}"
+    patch_discovery_ignition: "{{ lookup('template', 'patch-discovery-ignition-hostname-workground.j2') }}"
+  when: use_hostname_workaround | bool == True
+
+- name: Load patch for discovery ignition
+  set_fact:
+    patch_discovery_ignition: "{{ (patch_discovery_ignition | default({})) | combine(lookup('template', 'patch-discovery-ignition.j2') | from_json) }}"
   when: disconnected | bool == True
 
 - debug: # noqa unnamed-task
@@ -52,7 +57,7 @@
 - name: Create infra_env_body
   set_fact:
     infra_env_body: "{{ infra_env_body | combine({'ignition_config_override': patch_discovery_ignition | to_json}) }}"
-  when: disconnected | bool == True
+  when: (disconnected | bool  or use_hostname_workaround | bool)
 
 - name: IP config
   set_fact:

--- a/roles/generate_discovery_iso/templates/patch-discovery-ignition-hostname-workground.j2
+++ b/roles/generate_discovery_iso/templates/patch-discovery-ignition-hostname-workground.j2
@@ -1,0 +1,40 @@
+{
+    "ignition": {
+        "version": "3.1.0"
+    },
+    "systemd": {
+        "units": [
+            {
+                "name": "set-hostname-workaround.service",
+                "enabled": true,
+                "contents": {{ (lookup('template', 'set-hostname-workaround.service.j2') | string) | to_json }}
+            }
+        ]
+    },
+    "storage": {
+        "files": [
+            {
+                "path": "/usr/local/bin/set-hostname-workaround.sh",
+                "mode": 420,
+                "overwrite": true,
+                "user": {
+                    "name": "root"
+                },
+                "contents": {
+                    "source": "data:text/plain;base64,{{ lookup('template', 'set-hostname-workaround.sh.j2') | string | b64encode }}"
+                }
+            },
+            {
+                "path": "/etc/NetworkManager/conf.d/NoRDNS.conf",
+                "mode": 420,
+                "overwrite": true,
+                "user": {
+                    "name": "root"
+                },
+                "contents": {
+                    "source": "data:text/plain;base64,{{ ("[main]\nhostname-mode=" + (nm_hostname_mode | default('none')) + "\n") | string | b64encode }}"
+                }
+            }
+        ]
+    }
+}

--- a/roles/generate_discovery_iso/templates/set-hostname-workaround.service.j2
+++ b/roles/generate_discovery_iso/templates/set-hostname-workaround.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Set hostname workaround for RDNS lookups setting hostname
+Before=systemd-user-sessions.service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=root
+Type=oneshot
+TimeoutSec=60
+ExecStart=/bin/bash /usr/local/bin/set-hostname-workaround.sh
+PrivateTmp=true
+RemainAfterExit=no
+
+[Install]
+WantedBy=agent.service

--- a/roles/generate_discovery_iso/templates/set-hostname-workaround.sh.j2
+++ b/roles/generate_discovery_iso/templates/set-hostname-workaround.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Hacky way of grabbing mac addresses 
+mac_addresses=$(cat /sys/class/net/*/address)
+
+# Set hostname based on the mac address
+{% for hostname in groups['nodes']  %}
+if (echo $mac_addresses | grep -i {{ hostvars[hostname]['mac'] }}) 
+then
+    echo {{ hostname }}.{{ cluster_name }}.{{ base_dns_domain }} > /etc/hostname
+    echo {{ hostname }}.{{ cluster_name }}.{{ base_dns_domain }} > /proc/sys/kernel/hostname
+    touch /home/core/set-hostname.done
+fi
+{% endfor %}
+
+exit 0


### PR DESCRIPTION
When using static IPs network manager will do reverse dns lookups to set the
hostname of the node. When that node is the boot strap is can set the hostname
as api-int.<cluster_domain> when the api_vip bridge is brought up. This causes
and issue with the bootkube container as it uses --network=host, podman will
therefore insert the hostname of the host into containers /etc/hosts pointing
it to 127.0.1.1. If the kubeboot container starts before network manager, network manager
reverts the hostname (as the brige is removed) then the bootkube container
will be unable to communicate with the clusters kubeapi as it will be redirected
to 127.0.1.1 as per the /etc/hosts file. This causes the cluster installation
to fail.

To work around this issue crucible has a flag use_hostname_workaround
this will set NetworkManager's hostname-mode=none. This means that network manger
will not set the hostname. It will also inject a systemd service to set the
hostname based on the mac address.