### PR TITLE
Add list ntp_server_allows

### DIFF
--- a/roles/setup_ntp/defaults/main.yml
+++ b/roles/setup_ntp/defaults/main.yml
@@ -6,3 +6,5 @@ ntp_pool_servers:
   - 3.us.pool.ntp.org
 
 enable_logging: false
+
+ntp_server_allows: "{% if ntp_server_allow is defined %}{{ [ntp_server_allow] }}{% else %}{{ [] }}{% endif %}"

--- a/roles/setup_ntp/templates/chrony.conf.j2
+++ b/roles/setup_ntp/templates/chrony.conf.j2
@@ -12,12 +12,13 @@ manual
 logdir /var/log/chrony
 log measurements statistics tracking
 {% endif %}
+
 allow 127.0.0.1
-{% if ntp_server_allow %}
-allow {{ ntp_server_allow }}
-{% endif %}
+{% for allow_server in ntp_server_allows %}
+allow {{ allow_server }}
+{% endfor %}
+
 server 127.0.0.1
 {% for item in ntp_pool_servers %}
 server {{ item }}
 {% endfor %}
-


### PR DESCRIPTION
Defaults to [ntp_server_allow] if ntp_server_allow is defined.
This will be required to allow dual stack installations to communicate
with chrony. It will also be useful for more lab settings where multiple
clusters are being set up.