### PR TITLE
validate_dns error var "domain" not found.

### DIFF
--- a/roles/insert_dns_records/defaults/main.yml
+++ b/roles/insert_dns_records/defaults/main.yml
@@ -1,5 +1,5 @@
 write_dnsmasq_config: true
-domain: "{{ cluster_name + '.' + base_dns_domain }}"
+domain: "{{ cluster_name }}.{{ base_dns_domain }}"
 host_ip_keyword: "ansible_host"
 dns_entries_file_name: "{{ 'dnsmasq.' + cluster_name + '.conf' }}"
 dns_bmc_domain: "infra.{{ base_dns_domain }}"

--- a/roles/validate_dns_records/defaults/main.yml
+++ b/roles/validate_dns_records/defaults/main.yml
@@ -4,3 +4,4 @@ required_domains:
   - "{{ '*.apps.' + domain }}"
 required_binary: dig
 required_binary_provided_in_package: bind-utils
+domain: "{{ cluster_name }}.{{ base_dns_domain }}"


### PR DESCRIPTION
- Fixed var "domain" in validate_dns role.
- Made the var "domain" more legible in validate_dns and insert_dns.