### PR TITLE
Fix: no pxe hosts found.

### DIFF
--- a/roles/display_deployment_plan/defaults/main.yml
+++ b/roles/display_deployment_plan/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+pxe_node_names: []

--- a/roles/display_deployment_plan/tasks/main.yml
+++ b/roles/display_deployment_plan/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
+- name: Get all PXE Nodes
+  set_fact:
+    pxe_node_names: "{{ pxe_node_names + [item] }}"
+  when: hostvars[item]['vendor'] | lower == 'pxe'
+  loop: "{{ groups['nodes'] }}"
+
 - name: Display deployment plan if interactive prompts are allowed
   when: not ((skip_interactive_prompts | default(false)) | bool)
   block:
-
     - name: Display inventory details and ask for user confirmation
       pause:
         prompt: "{{ lookup('template', 'plan.j2').strip('\n') }}"
@@ -29,7 +34,7 @@
           hosts_missing: "<no hosts set>"
           groups_missing: "<no groups set>"
           kubeadmin_vault_password_file_path_missing: "UNDEFINED (This means the kubeadmin credentals will be stored in plain text)"
-
+          pxe_hosts_missing: "[WARNING] No hosts are set"
         cached_image_hash_file_path: "{{ image_hashes_path | default(repo_root_path + '/image_hashes.yml') }}"
 
         # A default error message is assigned to each variable referenced in the deployment plan.
@@ -48,6 +53,7 @@
           setup_http_store_service: "{{ setup_http_store_service | default(messages.value_missing) }}"
           setup_assisted_installer: "{{ setup_assisted_installer | default(messages.value_missing) }}"
           setup_pxe_service: "{{ setup_pxe_service | default(messages.value_missing) }}"
+          num_pxe_nodes: "{{ pxe_node_names | length }}"
           discovery_iso_name: "{{ discovery_iso_name | default(messages.value_missing) }}"
           discovery_iso_download_path: "{{ iso_download_dest_path | default(messages.value_missing) }}"
           is_valid_single_node_openshift_config: "{{ is_valid_single_node_openshift_config | default(messages.value_missing) }}"

--- a/roles/display_deployment_plan/templates/plan.j2
+++ b/roles/display_deployment_plan/templates/plan.j2
@@ -24,7 +24,12 @@ An OpenShift cluster is about to be deployed. Please double check the provided i
   {{ row_format_str | format('Setup HTTP Store Service', inventory.setup_http_store_service) }}
   {{ row_format_str | format('Setup Assisted Installer', inventory.setup_assisted_installer) }}
   {{ row_format_str | format('Setup PXE Service', inventory.setup_pxe_service) }}
-
+  {% if inventory.setup_pxe_service | bool and inventory.num_pxe_nodes | int > 0 -%}
+  {{ row_format_str | format('Number of PXE Nodes', inventory.num_pxe_nodes) }}
+  {% elif inventory.setup_pxe_service | bool and inventory.num_pxe_nodes | int == 0 +%}
+  {{ row_format_str | format('Number of PXE Nodes', messages.pxe_hosts_missing) }}
+  {% else %}
+  {% endif +%}
   {{ row_format_str | format('Discovery ISO Name', inventory.discovery_iso_name) }}
   {{ row_format_str | format('Discovery ISO Download Path', inventory.discovery_iso_download_path) }}
 

--- a/roles/validate_inventory/tasks/validate_pxe.yml
+++ b/roles/validate_inventory/tasks/validate_pxe.yml
@@ -8,37 +8,29 @@
     quiet: true
   when: hostvars['dns_host']['use_pxe'] | default(false)
 
-- name: Get all PXE Nodes
-  vars:
-    pxe_node_names: []
-  set_fact:
-    pxe_node_names: "{{ pxe_node_names + [item] }}"
-  when: hostvars[item]['vendor'] | lower == 'pxe'
-  loop: "{{ groups['nodes'] }}"
-
-- block:
-  - name: "Check if ipmitool installed"
-    ansible.builtin.shell:
-      cmd: "ipmitool -V"
-    register: ipmitool_check
-    ignore_errors: True
-    changed_when: False
-  
-  - name: Record failures
-    fail:
-      msg: "ipmitool must be installed for pxe installatio"
-    when: ipmitool_check.rc != 0
-  
-  - name: "Check if pyghmi installed"
-    ansible.builtin.shell:
-      cmd: "pip3 show pyghmi"
-    register: pyghmi_check
-    ignore_errors: True
-    changed_when: False
-  
-  - name: Record failures
-    fail:
-      msg: "pyghmi must be installed for pxe installation"
-    when: pyghmi_check.rc != 0
-  when: pxe_node_names | length >= 1
+- name: Check for ipmitool and pyghmi
   delegate_to: bastion
+  block:
+    - name: "Check if ipmitool installed"
+      ansible.builtin.shell:
+        cmd: "ipmitool -V"
+      register: ipmitool_check
+      ignore_errors: True
+      changed_when: False
+    
+    - name: Record failures
+      fail:
+        msg: "ipmitool must be installed for pxe installation"
+      when: ipmitool_check.rc != 0
+    
+    - name: "Check if pyghmi installed"
+      ansible.builtin.shell:
+        cmd: "pip3 show pyghmi"
+      register: pyghmi_check
+      ignore_errors: True
+      changed_when: False
+    
+    - name: Record failures
+      fail:
+        msg: "pyghmi must be installed for pxe installation"
+      when: pyghmi_check.rc != 0


### PR DESCRIPTION
- Fixed an issue where crucible crashes if setup_pxe_service is true and hosts:vendor is not set to pxe.
- The setup of the pxe service should not be tied to whether or not any host will use pxe.