### PR TITLE
Make cluster id filenames variables

### DIFF
--- a/roles/create_cluster/defaults/main.yml
+++ b/roles/create_cluster/defaults/main.yml
@@ -33,3 +33,4 @@ single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | defau
 high_availability_mode: "{{ single_node_openshift_enabled | ternary('none', 'full') }}"
 
 create_body_extras: {}
+cluster_id_filename: "cluster.txt" # This default is for backwards compatability

--- a/roles/create_cluster/tasks/main.yml
+++ b/roles/create_cluster/tasks/main.yml
@@ -75,7 +75,7 @@
 - name: "Save cluster_id"
   copy:
     content: "{{ cluster_id }}"
-    dest: "{{ fetched_dest }}/cluster.txt"
+    dest: "{{ fetched_dest }}/{{ cluster_id_filename }}"
     mode: 0644
   delegate_to: localhost
   become: no

--- a/roles/create_day2_cluster/defaults/main.yml
+++ b/roles/create_day2_cluster/defaults/main.yml
@@ -25,3 +25,4 @@ manifest_templates:
   - 50-worker-remove-ipi-leftovers.yml
 
 fetched_dest: "{{ repo_root_path }}/fetched"
+day2_cluster_id_filename: day2_cluster.txt # This default is for backwards compatibility

--- a/roles/create_day2_cluster/tasks/main.yml
+++ b/roles/create_day2_cluster/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: "Save add_host_cluster_id"
   copy:
     content: "{{ add_host_cluster_id }}"
-    dest: "{{ fetched_dest }}/day2_cluster.txt"
+    dest: "{{ fetched_dest }}/{{ day2_cluster_id_filename }}"
     mode: 0644
   delegate_to: localhost
   become: no


### PR DESCRIPTION
It is now possible to override the default filenames using cluster_id_filename and day2_cluster_id_filename respectively

Note: I have made the defaults retain the previous behaviour.