### PR TITLE
Have sushy tools installed in a virtual env

### DIFF
--- a/roles/setup_sushy_tools/defaults/main.yml
+++ b/roles/setup_sushy_tools/defaults/main.yml
@@ -8,6 +8,10 @@ sushy_data_dir: "{{ sushy_dir }}/data"
 sushy_packages:
   - python3-pip
   - python3-virtualenv
+  - libvirt-devel
+sushy_pip_packages:
+  - sushy-tools
+  - libvirt-python
 
 file_owner: "{{ ansible_env.USER }}"
 file_group: "{{ file_owner }}"

--- a/roles/setup_sushy_tools/defaults/main.yml
+++ b/roles/setup_sushy_tools/defaults/main.yml
@@ -8,6 +8,7 @@ sushy_data_dir: "{{ sushy_dir }}/data"
 sushy_packages:
   - python3-pip
   - python3-virtualenv
+  - gcc
   - libvirt-devel
 sushy_pip_packages:
   - sushy-tools

--- a/roles/setup_sushy_tools/defaults/main.yml
+++ b/roles/setup_sushy_tools/defaults/main.yml
@@ -5,6 +5,9 @@ sushy_auth_dir: "{{ sushy_dir }}/auth"
 sushy_cert_dir: "{{ sushy_dir }}/cert"
 sushy_auth_file: "{{ sushy_auth_dir }}/htpasswd"
 sushy_data_dir: "{{ sushy_dir }}/data"
+sushy_packages:
+  - python3-pip
+  - python3-virtualenv
 
 file_owner: "{{ ansible_env.USER }}"
 file_group: "{{ file_owner }}"

--- a/roles/setup_sushy_tools/tasks/main.yml
+++ b/roles/setup_sushy_tools/tasks/main.yml
@@ -20,9 +20,8 @@
 
     - name: Install sushy-tools via pip in a virtual environment
       pip:
-        name: "{{ item }}"
+        name: "{{ sushy_pip_packages }}"
         virtualenv: "{{ sushy_dir }}"
-      loop: "{{ sushy_pip_packages }}"
 
     - name: Install httpd-tools for htpasswd
       package:

--- a/roles/setup_sushy_tools/tasks/main.yml
+++ b/roles/setup_sushy_tools/tasks/main.yml
@@ -2,9 +2,26 @@
 - name: Install sushy-tools
   become: true
   block:
-    - name: Install sushy-tools via pip3
+    - name: Install required packages
+      package:
+        name: "{{ sushy_packages }}"
+        state: present
+
+    - name: "Create sushy-tools directory {{ item }}"
+      file:
+        path: "{{ item }}"
+        state: directory
+        mode: 0755
+      loop:
+        - "{{ sushy_dir }}"
+        - "{{ sushy_auth_dir }}"
+        - "{{ sushy_cert_dir }}"
+        - "{{ sushy_data_dir }}"
+
+    - name: Install sushy-tools via pip3 in a virtual environment
       pip:
         name: "sushy-tools"
+        virtualenv: "{{ sushy_dir }}"
 
     - name: Install httpd-tools for htpasswd
       package:
@@ -19,17 +36,6 @@
         permanent: yes
         immediate: yes
       loop: "{{ [sushy_tools_port] | product(['internal', 'public']) | list }}"
-
-    - name: "Create sushy-tools conf directory {{ item }}"
-      file:
-        path: "{{ item }}"
-        state: directory
-        mode: 0755
-      loop:
-        - "{{ sushy_dir }}"
-        - "{{ sushy_auth_dir }}"
-        - "{{ sushy_cert_dir }}"
-        - "{{ sushy_data_dir }}"
 
     - name: Secure sushy tools
       when: secure_sushy_tools | bool

--- a/roles/setup_sushy_tools/tasks/main.yml
+++ b/roles/setup_sushy_tools/tasks/main.yml
@@ -18,10 +18,11 @@
         - "{{ sushy_cert_dir }}"
         - "{{ sushy_data_dir }}"
 
-    - name: Install sushy-tools via pip3 in a virtual environment
+    - name: Install sushy-tools via pip in a virtual environment
       pip:
-        name: "sushy-tools"
+        name: "{{ item }}"
         virtualenv: "{{ sushy_dir }}"
+      loop: "{{ sushy_pip_packages }}"
 
     - name: Install httpd-tools for htpasswd
       package:

--- a/roles/setup_sushy_tools/templates/sushy-tools.service.j2
+++ b/roles/setup_sushy_tools/templates/sushy-tools.service.j2
@@ -6,7 +6,7 @@ After=network.target syslog.target
 Type=simple
 TimeoutStartSec=5m
 WorkingDirectory={{ sushy_dir }}
-ExecStart=/usr/local/bin/sushy-emulator --config {{ sushy_dir }}/sushy-emulator.conf
+ExecStart={{ sushy_dir }}/bin/sushy-emulator --config {{ sushy_dir }}/sushy-emulator.conf
 Restart=always
 
 [Install]


### PR DESCRIPTION
Currently, sushy tools is installed in the system-wide python path, this causes issues with e.g. newer versions of libraries in the sushy releases, and overwriting RPM files with PIP files. Also adjusting the systemd service file to use the virtual environment.