### PR TITLE
Only use schedulable_masters when cluster has workers

### DIFF
--- a/roles/create_cluster/defaults/main.yml
+++ b/roles/create_cluster/defaults/main.yml
@@ -31,6 +31,7 @@ single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | defau
 # 2. 'Full' (otherwise)
 #     Requires at least three master nodes for High Availability.
 high_availability_mode: "{{ single_node_openshift_enabled | ternary('none', 'full') }}"
+has_workers: "{{ (groups['workers'] | default([])) | length > 0 }} "
 
 create_body_extras: {}
 cluster_id_filename: "cluster.txt" # This default is for backwards compatability

--- a/roles/create_cluster/tasks/main.yml
+++ b/roles/create_cluster/tasks/main.yml
@@ -28,9 +28,13 @@
           "https_proxy": https_proxy,
           "no_proxy": no_proxy,
           "additional_ntp_source": ntp_server,
-          "schedulable_masters": schedulable_masters, 
         } | to_json
       }}'
+
+- name: Assign schedulable_masters if cluster has workers
+  set_fact:
+    create_body_extras: "{{ create_body_extras | combine({'schedulable_masters': schedulable_masters }) }}"
+  when: has_workers | bool
 
 - name: Add network_type to extras for create_body
   set_fact:

--- a/roles/patch_cluster/defaults/main.yml
+++ b/roles/patch_cluster/defaults/main.yml
@@ -28,11 +28,9 @@ manifest_templates_for_mode:
     - 50-worker-nm-fix-ipv6.yml
     - 50-worker-remove-ipi-leftovers.yml
     # - 02-fix-ingress-config.yml     # Applying this fix breaks the ingress controller on SNO.
-    # - 01-master-node-scheduler.yml  # The master node on SNO is automatically marked as schedulable.
   full:
     - 50-worker-nm-fix-ipv6.yml
     - 50-worker-remove-ipi-leftovers.yml
     - 02-fix-ingress-config.yml
-    - 01-master-node-scheduler.yml
 
 manifest_templates: "{{ manifest_templates_for_mode[high_availability_mode] }}"


### PR DESCRIPTION
Without workers masters have to schedulable so we will ignore the user provided parameter. Also removed manifest as it meant that the user var meant nothing as masters will always be schedulable regardless of the user's choice of value.