### PR TITLE
Fix installation fail msg in monitor_cluster role

### DIFF
--- a/roles/monitor_cluster/tasks/main.yml
+++ b/roles/monitor_cluster/tasks/main.yml
@@ -14,7 +14,7 @@
   delay: 60
   delegate_to: bastion
 
-- name: "Fail installation because user cancelled (ERROR)"
+- name: "Fail installation because of cluster error (ERROR)"
   fail:
     msg: "Cluster installation failed - Reset the installation process to return to the configuration and try again"
   when: cluster.json.status == 'error'


### PR DESCRIPTION
It looks like the cluster installation failure message for an encountered error is copy-pasted improperly (it indicates `user cancelled` when the task itself is checking for a cluster error)