### PR TITLE
Add version infomation to image_hashes file

### DIFF
--- a/docs/v1_to_v2_transition.md
+++ b/docs/v1_to_v2_transition.md
@@ -1,12 +1,12 @@
-# API v1 to v2 transition. 
+# API v1 to v2 transition.
 
-Crucible has moved from assisted installer v1 API to v2. 
-In doing so we have renamed the pod running assisted installer to be inline with assisted installers podman deployment documentation. 
-To allow the transition to take play you will need to remove the v1 assisted installer pod `podman pod rm -f assisted-service`. 
-It may also help to remove anything left behind from the previous pod in the `assisted_installer_dir`(default: `/opt/assisted-installer`). 
+Crucible has moved from assisted installer v1 API to v2.
+In doing so we have renamed the pod running assisted installer to be inline with assisted installers podman deployment documentation.
+To allow the transition to take play you will need to remove the v1 assisted installer pod `podman pod rm -f assisted-service`.
+It may also help to remove anything left behind from the previous pod in the `assisted_installer_dir`(default: `/opt/assisted-installer`).
 You may want to back this up if you need any infomation the then previous deployments held in assisted installer.
 
-In addition to the three previous containers, there is a new image service. 
+In addition to the three previous containers, there is a new image service.
 For assisted installer to work correctly with this service the assisted installer pod must be able to resolve the image service (by default this will be the `host` var in the `assisted_installer` host definition). So if a domain is being used you will need to add the ip address to your DNS server to the `dns_servers` in the `assisted_installer` host definition:
 
 ```yaml
@@ -16,7 +16,7 @@ services:
     assisted_installer:
       ansible_host: service_host.example.lab
       host: service_host.example.lab
-      port: 8090 
+      port: 8090
       dns_servers:
         - 10.40.0.100
         - 8.8.8.8
@@ -31,7 +31,7 @@ The Assisted Installer has changed the structure of the required data for defini
 assisted_service_openshift_versions_defaults:
   "4.6":
     display_name: 4.6.16
-    release_image: "quay.io/openshift-release-dev/ocp-release{% if 'release_4.6' in image_hashes %}@{{ image_hashes['release_4.6'] }}{% else %}:4.6.17-x86_64{% endif %}"
+    release_image: "quay.io/openshift-release-dev/ocp-release{% if 'release_4.6' in image_hashes %}@{{ image_hashes['release_4.6'].hash }}{% else %}:4.6.17-x86_64{% endif %}"
     release_version: 4.6.16
     rhcos_image: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso
     rhcos_rootfs: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img
@@ -60,4 +60,4 @@ release_images:
 
 ## Proxy
 
-For people using proxies you will need to make HTTP_PROXY, HTTPS_PROXY and NO_PROXY all lower case. 
+For people using proxies you will need to make HTTP_PROXY, HTTPS_PROXY and NO_PROXY all lower case.

--- a/roles/get_image_hash/defaults/main.yml
+++ b/roles/get_image_hash/defaults/main.yml
@@ -101,13 +101,19 @@ assisted_service_image_repo_url: quay.io/edge-infrastructure
 assisted_installer_images:
   controller:
     url: "{{ assisted_service_image_repo_url }}/assisted-installer-controller:{{ controller_tag }}"
+    version: "{{ controller_tag }}"
   installer_agent:
     url: "{{ assisted_service_image_repo_url }}/assisted-installer-agent:{{ installer_agent_tag }}"
+    version: "{{ installer_agent_tag }}"
   installer:
     url: "{{ assisted_service_image_repo_url }}/assisted-installer:{{ installer_tag }}"
+    version: "{{ installer_tag }}"
   service:
     url: "{{ assisted_service_image_repo_url }}/assisted-service:{{ assisted_service_tag }}"
+    version: "{{ assisted_service_tag }}"
   gui:
     url: "{{ assisted_service_image_repo_url }}/assisted-installer-ui:{{ assisted_service_gui_tag }}"
+    version: "{{ assisted_service_gui_tag }}"
   image_service:
     url: "{{ assisted_service_image_repo_url }}/assisted-image-service:{{ assisted_service_image_service_tag }}"
+    version: "{{ assisted_service_image_service_tag }}"

--- a/roles/get_image_hash/tasks/get_image_hash.yml
+++ b/roles/get_image_hash/tasks/get_image_hash.yml
@@ -6,11 +6,19 @@
     register: result
     changed_when: false
 
-  - name: Update hashes
+  - name: "Set hash version"
     set_fact:
-      image_hashes: "{{ image_hashes | combine({item.key:  (result.stdout | from_json | json_query('Digest'))}) }}"
+      versioned_hash:
+        hash: "{{ result.stdout | from_json | json_query('Digest') }}"
+        version: "{{ item.value.version |  default(item.value.url.split(':')[-1]) }}" # Take a guess of a version if one is not supplied
 
 - name: "A hash was provided, only update the hash dict"
   when: (item.value.hash | default('')) != ''
   set_fact:
-    image_hashes: "{{ image_hashes | combine({item.key:  item.value.hash}) }}"
+    versioned_hash:
+      hash: "{{ item.value.hash }}"
+      version: "{{ item.value.version |  default(item.url.split(':')[-1]) }}" # Take a guess of a version if one is not supplied
+
+- name: Update hashes
+  set_fact:
+    image_hashes: "{{ image_hashes | combine({item.key:  versioned_hash}) }}"

--- a/roles/get_image_hash/tasks/main.yml
+++ b/roles/get_image_hash/tasks/main.yml
@@ -39,6 +39,7 @@
         { ('release_' + item.version + '_' + item.cpu_architecture) : {
             'url': item.url,
             'hash': item.hash | default(''),
+            'version': item.version | default(item.url.split(':')[-1]),
           }
         })
       }}"
@@ -53,7 +54,7 @@
     apply:
       tags:
         - install
-  when: item.key not in image_hashes
+  when: item.key not in image_hashes or item.value.version != ((image_hashes[item.key] | default({})).version | default(''))
   loop: "{{ images_to_get_hash_for | dict2items }}"
 
 - name: Create image cache file
@@ -76,7 +77,10 @@
 
     - name: Update released items (image:tag format)
       set_fact:
-        updated_release_images: "{{ updated_release_images | default([]) + [item | combine({'url': item.url.rsplit(':', 1)[0] + '@' + image_hashes['release_' + item.version + '_' + item.cpu_architecture]  })] }}"
+        updated_release_images: "{{
+          updated_release_images | default([]) +
+            [item | combine({'url': (item.url.rsplit(':', 1)[0] + '@' + image_hashes['release_' + item.version + '_' + item.cpu_architecture].hash)})]
+          }}"
       when:
         - ('@' not in item.url)
         - (':' in item.url)

--- a/roles/populate_mirror_registry/defaults/main.yml
+++ b/roles/populate_mirror_registry/defaults/main.yml
@@ -31,31 +31,31 @@ local_registry: "{{ registry_fqdn }}:{{ registry_port }}"
 registry_port: 5000
 
 installer_agent_image:
-  remote: "quay.io/edge-infrastructure/assisted-installer-agent@{{ image_hashes.installer_agent }}"
+  remote: "quay.io/edge-infrastructure/assisted-installer-agent@{{ image_hashes.installer_agent.hash }}"
   local: "{{ local_registry }}/ocpmetal/assisted-installer-agent"
   local_tag: "latest"
 
 installer_image:
-  remote: "quay.io/edge-infrastructure/assisted-installer@{{ image_hashes.installer }}"
+  remote: "quay.io/edge-infrastructure/assisted-installer@{{ image_hashes.installer.hash }}"
   local: "{{ local_registry }}/ocpmetal/assisted-installer"
   local_tag: "latest"
 
 installer_controller_image:
-  remote: "quay.io/edge-infrastructure/assisted-installer-controller@{{ image_hashes.controller }}"
+  remote: "quay.io/edge-infrastructure/assisted-installer-controller@{{ image_hashes.controller.hash }}"
   local: "{{ local_registry }}/ocpmetal/assisted-installer-controller"
   local_tag: "latest"
 
 release_image_remote: "quay.io/openshift-release-dev/ocp-release"
 
 release_image_item:
-  remote: "{{ release_image_remote }}@{{ image_hashes['release_' + (openshift_full_version | string) + '_x86_64'] }}"
+  remote: "{{ release_image_remote }}@{{ image_hashes['release_' + (openshift_full_version | string) + '_x86_64'].hash }}"
   local: "{{ local_registry }}/ocp4/openshift4"
   local_tag: "{{ openshift_full_version }}-x86_64"
 
 arm_release_image_key: "release_{{ openshift_full_version | string }}_arm64"
 
 release_image_item_arm:
-  remote: "{{ release_image_remote }}@{{ image_hashes[arm_release_image_key] }}"
+  remote: "{{ release_image_remote }}@{{ image_hashes[arm_release_image_key].hash }}"
   local: "{{ local_registry }}/ocp4/openshift4"
   local_tag: "{{ openshift_full_version }}-aarch64"
 

--- a/roles/setup_assisted_installer/defaults/main.yml
+++ b/roles/setup_assisted_installer/defaults/main.yml
@@ -1,13 +1,13 @@
 assisted_service_image_repo: "edge-infrastructure"
 assisted_service_image_repo_url: "quay.io/{{ assisted_service_image_repo }}"
 
-assisted_service_image: "{{ assisted_service_image_repo_url }}/assisted-service@{{ image_hashes.service }}"
-assisted_service_gui_image: "{{ assisted_service_image_repo_url }}/assisted-installer-ui@{{ image_hashes.gui }}"
-assisted_service_image_service_image: "{{ assisted_service_image_repo_url }}/assisted-image-service@{{ image_hashes.image_service }}"
+assisted_service_image: "{{ assisted_service_image_repo_url }}/assisted-service@{{ image_hashes.service.hash }}"
+assisted_service_gui_image: "{{ assisted_service_image_repo_url }}/assisted-installer-ui@{{ image_hashes.gui.hash }}"
+assisted_service_image_service_image: "{{ assisted_service_image_repo_url }}/assisted-image-service@{{ image_hashes.image_service.hash }}"
 
-assisted_service_controller_image: "{{ assisted_service_image_repo_url }}/assisted-installer-controller@{{ image_hashes.controller }}"
-assisted_service_installer_agent_image: "{{ assisted_service_image_repo_url }}/assisted-installer-agent@{{ image_hashes.installer_agent }}"
-assisted_service_installer_image: "{{ assisted_service_image_repo_url }}/assisted-installer@{{ image_hashes.installer }}"
+assisted_service_controller_image: "{{ assisted_service_image_repo_url }}/assisted-installer-controller@{{ image_hashes.controller.hash }}"
+assisted_service_installer_agent_image: "{{ assisted_service_image_repo_url }}/assisted-installer-agent@{{ image_hashes.installer_agent.hash }}"
+assisted_service_installer_image: "{{ assisted_service_image_repo_url }}/assisted-installer@{{ image_hashes.installer.hash }}"
 assisted_postgres_image: quay.io/centos7/postgresql-12-centos7:latest
 assisted_installer_dir: /opt/assisted-installer
 assisted_installer_data_dir: "{{ assisted_installer_dir }}/data"


### PR DESCRIPTION
This is to stop issues when the image implicitly changes e.g. assisted installer version is bumped. Before this the user would have to know that they need to remove the image hashes file to get the new version.