### PR TITLE
Create day2 KVM nodes as part of day2 process

### DIFF
--- a/deploy_day2_workers.yml
+++ b/deploy_day2_workers.yml
@@ -1,4 +1,14 @@
 ---
+- import_playbook: playbooks/create_vms.yml
+  when: groups['day2_workers'] | default([]) | length > 0
+  vars:
+    nodes_to_process: "{{ groups['day2_workers'] | default([]) }}"
+    # DELETE_VM_BRIDGE is set to false because removing the bridge
+    # and vlan interface (if shared with the main cluster) will
+    # break the connection to the cluster that the day 2 nodes
+    # are trying to join
+    DELETE_VM_BRIDGE: false
+
 - import_playbook: playbooks/create_day2_cluster.yml
 
 - import_playbook: playbooks/generate_discovery_iso.yml

--- a/deploy_prerequisites.yml
+++ b/deploy_prerequisites.yml
@@ -11,6 +11,8 @@
 - import_playbook: playbooks/deploy_http_store.yml
 
 - import_playbook: playbooks/create_vms.yml
+  vars:
+    nodes_to_process: "{{ groups['masters'] + groups['workers'] | default([]) }}"
 
 - import_playbook: playbooks/deploy_tftp.yml
 

--- a/roles/add_day2_node/tasks/main.yml
+++ b/roles/add_day2_node/tasks/main.yml
@@ -74,7 +74,7 @@
       import_role:
         name: monitor_host
       vars:
-        cluster_id: "{{ add_host_cluster_id }}"
+        monitor_cluster_id: "{{ add_host_cluster_id }}"
         current_host: "{{ discovered_host_reply.json }}"
         waiting_termination_states:
           - "added-to-existing-cluster"

--- a/roles/add_day2_node/tasks/main.yml
+++ b/roles/add_day2_node/tasks/main.yml
@@ -3,12 +3,14 @@
   block:
     - name: "Wait for up to 20 minutes for {{ inventory_hostname }} to be discovered"
       uri:
-        url: "{{ URL_ASSISTED_INSTALLER_CLUSTER }}"
+        url: "{{ URL_ASSISTED_INSTALLER_CLUSTER }}?with-inventory=True"
         method: GET
         status_code: [200, 201]
         return_content: True
       register: cluster
-      until: (hostvars[inventory_hostname]['mac'] | upper) in (cluster.json.hosts | map(attribute='inventory') | map('from_json') | map(attribute='interfaces') | flatten | map(attribute='mac_address') | map('upper') | list)
+      until:
+        - ("json" in cluster)
+        - (hostvars[inventory_hostname]['mac'] | upper) in (cluster.json.hosts | map(attribute='inventory') | map('from_json') | map(attribute='interfaces') | flatten | map(attribute='mac_address') | map('upper') | list)
       retries: 20
       delay: 60
 

--- a/roles/create_day2_cluster/tasks/main.yml
+++ b/roles/create_day2_cluster/tasks/main.yml
@@ -10,7 +10,7 @@
     body: >-
       {
         "name": "{{ cluster_name + '-day2' }}",
-        "api_vip_dnsname": "{{ 'api.' + cluster_name + '.' + base_dns_domain }}",
+        "api_vip_dnsname": "api.{{ cluster_name }}.{{ base_dns_domain }}",
         "openshift_cluster_id": "{{ cluster_id }}",
         "openshift_version": "{{ openshift_full_version }}"
       }

--- a/roles/destroy_vms/tasks/destroy_networks.yml
+++ b/roles/destroy_vms/tasks/destroy_networks.yml
@@ -22,7 +22,7 @@
     - "{{ vm_bridge_interface }}_{{ vm_bridge_name }}"
   ignore_errors: yes
   become: true
-  when: (SETUP_VM_BRIDGE | default(true)) | bool == true
+  when: (DELETE_VM_BRIDGE | default(SETUP_VM_BRIDGE | default(true))) | bool == true
 
 - name: Delete existing bridges (if any)
   community.general.nmcli:
@@ -31,4 +31,4 @@
     state: absent
   ignore_errors: yes
   become: true
-  when: (SETUP_VM_BRIDGE | default(true)) | bool == true and vm_vlan_tag is defined
+  when: (DELETE_VM_BRIDGE | default(SETUP_VM_BRIDGE | default(true))) | bool == true and vm_vlan_tag is defined

--- a/roles/destroy_vms/tasks/main.yml
+++ b/roles/destroy_vms/tasks/main.yml
@@ -1,11 +1,10 @@
 - name: Create inventory host to vm name mapper
   set_fact:
-    cluster_vm_names: "{{ (cluster_vm_names | default([])) + [item.startswith(vm_node_prefix) | ternary(item, (vm_node_prefix + item))] }}"
-  loop: "{{ groups['nodes'] }}"
-  when: hostvars[item]['vendor'] | lower == 'kvm'
+    cluster_vm_names: "{{ (cluster_vm_names | default([])) + [item.name] }}"
+  loop: "{{ kvm_nodes }}"
 
 - debug: # noqa unnamed-task
-    var: vm_to_inventory_mapper
+    var: cluster_vm_names
     verbosity: 1
 
 - name: Setup host environment

--- a/roles/generate_discovery_iso/tasks/main.yml
+++ b/roles/generate_discovery_iso/tasks/main.yml
@@ -130,7 +130,7 @@
           passwd:
             users: "{{ [discovery_content.passwd.users[0] | combine({'passwordHash': hashed_discovery_password})] }}"
 
-    - name: Create Infra env
+    - name: Patch Infra env
       vars:
         previous_patches: "{{ patch_discovery_ignition | default({}) }}"
       uri:

--- a/roles/monitor_host/defaults/main.yml
+++ b/roles/monitor_host/defaults/main.yml
@@ -4,12 +4,11 @@
 monitor: True
 secure: False
 
-cluster_id: "{{ hostvars['bastion']['cluster_id'] }}"
-
-ASSISTED_INSTALLER_HOST: "{{ hostvars['assisted_installer']['host'] | default(ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0])) }}"
+monitor_cluster_id: "{{ cluster_id | default(hostvars['bastion']['cluster_id']) }}"
+ASSISTED_INSTALLER_HOST: "{{ hostvars['assisted_installer']['host'] | default(ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0])) }}"
 ASSISTED_INSTALLER_PORT: "{{ hostvars['assisted_installer']['port'] | default(8090) }}"
 ASSISTED_INSTALLER_BASE_URL: "{{ secure | ternary('https', 'http') }}://{{ ASSISTED_INSTALLER_HOST }}:{{ ASSISTED_INSTALLER_PORT }}/api/assisted-install/v2"
-URL_ASSISTED_INSTALLER_CLUSTER: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ cluster_id }}"
+URL_ASSISTED_INSTALLER_CLUSTER: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ monitor_cluster_id }}"
 URL_ASSISTED_INSTALLER_INFRA_ENV: "{{ ASSISTED_INSTALLER_BASE_URL }}/infra-envs/{{ infra_env_id }}"
 
 # HTTP Basic Authentication

--- a/roles/monitor_host/tasks/main.yml
+++ b/roles/monitor_host/tasks/main.yml
@@ -9,6 +9,9 @@
     return_content: True
   register: cluster
   delegate_to: bastion
+  until: cluster is successful
+  retries: 4
+  delay: 30
 
 - debug: # noqa unnamed-task
     msg: "{{ cluster.json.hosts }}"

--- a/roles/process_kvm_nodes/defaults/main.yml
+++ b/roles/process_kvm_nodes/defaults/main.yml
@@ -19,3 +19,5 @@ vm_group_params:
     disk_size: "{{ vm_spec_worker_disk_size | default(vm_spec_defaults.worker.disk_size) }}"
 
 vm_node_prefix: "{{ cluster_name }}_"
+
+nodes_to_process: "{{ groups['nodes'] }}"

--- a/roles/process_kvm_nodes/tasks/create_node.yml
+++ b/roles/process_kvm_nodes/tasks/create_node.yml
@@ -17,7 +17,7 @@
   set_fact:
     vm_hostname: "{{ hostvars[kvm_node_hostname]['vm_host'] }}"
     vm_mac: "{{ hostvars[kvm_node_hostname]['mac'] }}"
-    
+
 - name: Set kvm_network_interfaces
   set_fact:
     kvm_network_interfaces: "{{
@@ -38,6 +38,6 @@
       disks: "{{ kvm_node_disks }}"
       network_interfaces: "{{ kvm_network_interfaces }}"
 
-- name: Update all_kvm_nodes
+- name: Update processed_kvm_nodes
   set_fact:
-    all_kvm_nodes: "{{ all_kvm_nodes | combine({kvm_node.vm_host: ((all_kvm_nodes[kvm_node.vm_host] | default([])) +  [kvm_node])}) }}"
+    processed_kvm_nodes: "{{ processed_kvm_nodes | combine({kvm_node.vm_host: ((processed_kvm_nodes[kvm_node.vm_host] | default([])) +  [kvm_node])}) }}"

--- a/roles/process_kvm_nodes/tasks/main.yml
+++ b/roles/process_kvm_nodes/tasks/main.yml
@@ -1,17 +1,17 @@
 - name: Set defualt for kvm_nodes
   set_fact:
-    all_kvm_nodes: {}
+    processed_kvm_nodes: {}
 
 - name: Set kvm_nodes
   include_tasks: create_node.yml
-  loop: "{{ groups['nodes'] }}"
+  loop: "{{ nodes_to_process }}"
   loop_control:
     loop_var: kvm_node_hostname
   when: hostvars[kvm_node_hostname]['vendor'] | lower == 'kvm'
 
 - name: Distribute kvm_nodes for vm_host to that host
   set_fact:
-    kvm_nodes: "{{ all_kvm_nodes[item] | default([]) }}"
+    kvm_nodes: "{{ processed_kvm_nodes[item] | default([]) }}"
   delegate_to: "{{ item }}"
   delegate_facts: true
   loop: "{{ groups['vm_hosts'] | default([]) }}"


### PR DESCRIPTION
This is becuase the day2 nodes maybe be added as a secondary run we must filter the kvm nodes otherwise the playbooks will destroy the current cluter.