### PR TITLE
Add support to OCP nightly builds for populate_mirror_registry/prerequisites

### DIFF
--- a/roles/populate_mirror_registry/defaults/main.yml
+++ b/roles/populate_mirror_registry/defaults/main.yml
@@ -17,9 +17,13 @@ downloads_path: "{{ ansible_env.HOME }}"
 image_name_registry: ocpdiscon-registry
 
 # oc and opm install
-release_url: "https://mirror.openshift.com/pub/openshift-v{{ openshift_version_parts[0] }}/clients/ocp"
-oc_tar: openshift-client-linux.tar.gz
-opm_tar: opm-linux.tar.gz
+# - oc tar will be retrieved from the release image, needs OCP full version.
+#   Stable client is also used to extract the artifacts from release image
+# - opm tar always has to come from stable release URL, so that its name is well known
+stable_release_url: "https://mirror.openshift.com/pub/openshift-v{{ openshift_version_parts[0] }}/clients/ocp/stable"
+oc_tar: "openshift-client-linux-{{ openshift_full_version }}.tar.gz"
+stable_oc_tar: "openshift-client-linux.tar.gz"
+stable_opm_tar: "opm-linux.tar.gz"
 
 # The information for the locally created registry
 registry_fqdn: "{{ ansible_fqdn }}"

--- a/roles/populate_mirror_registry/tasks/prerequisites.yml
+++ b/roles/populate_mirror_registry/tasks/prerequisites.yml
@@ -1,4 +1,16 @@
 ---
+- name: Check that release_url variable is not defined
+  assert:
+    that:
+      - release_url is not defined
+    fail_msg: >
+      release_url is no longer needed in this role, the
+      functionality around it has changed.
+      Now, artifacts are directly extracted from release image,
+      and they are not downloaded from release_url.
+      Please make sure not to use release_url variable and
+      to check that you are using the correct release image
+
 - name: Make sure needed packages are installed
   package:
     name: tar
@@ -16,39 +28,62 @@
     - "{{ downloads_path }}"
     - "{{ downloads_path }}/{{ openshift_full_version }}"
 
+- name: Check if artifacts from release image have already been downloaded
+  stat:
+    path: "{{ downloads_path }}/{{ openshift_full_version }}/release.txt"
+  register: downloaded_artifacts
+
+# extract artifacts from the OCP release image instead of downloading them
+# from the release URL
+# This OCP release image provides the artifacts required (OCP clients, installer,
+# release.txt, among others)
+- name: Extract artifacts from release image
+  become: true
+  block:
+    # we need to temporarily download ocp stable binary to extract the artifacts
+    - name: Create tmp directory for oc stable client
+      tempfile:
+        state: directory
+        prefix: oc.
+      register: oc_tmp_dir
+
+    - name: Download stable client
+      unarchive:
+        src: "{{ stable_release_url }}/{{ stable_oc_tar }}"
+        dest: "{{ oc_tmp_dir.path }}"
+        mode: 0755
+        remote_src: yes
+
+    - name: Extract artifacts from release image (x86_64)
+      command:
+        cmd: >
+          "{{ oc_tmp_dir.path }}/oc" adm release extract
+            --registry-config "{{ config_file_path }}/{{ pull_secret_file_name }}"
+            --tools
+            --from  "{{ release_image_item.remote | quote }}"
+            --to "{{ downloads_path }}/{{ openshift_full_version }}"
+
+    - name: Remove temporary oc stable client
+      file:
+        path: "{{ oc_tmp_dir.path }}"
+        state: absent
+  when:
+    - not downloaded_artifacts.stat.exists
+
 - name: Setup Version/Image facts
   block:
-    - name: Get Release.txt File
-      uri:
-        url: "{{ release_url }}/{{ openshift_full_version }}/release.txt"
-        return_content: yes
+    - name: "Read Release.txt downloaded file"
+      slurp:
+        src: "{{ downloads_path }}/{{ openshift_full_version }}/release.txt"
       register: result
-      until: result.status == 200
-      retries: 6 # 1 minute (10 * 6)
-      delay: 10 # Every 10 seconds
-      failed_when: result.content|length == 0 or result.status >= 400
 
     - name: Set Fact for Release Image
       set_fact:
-        release_version: "{{ result.content | regex_search('Version:.*') | regex_replace('Version:\\s*(.*)', '\\1') }}"
-        release_image: "{{ result.content | regex_search('Pull From:.*') | regex_replace('Pull From:\\s*(.*)', '\\1') }}"
+        release_version: "{{ result.content | b64decode | regex_search('Version:.*') | regex_replace('Version:\\s*(.*)', '\\1') }}"
+        release_image: "{{ result.content | b64decode | regex_search('Pull From:.*') | regex_replace('Pull From:\\s*(.*)', '\\1') }}"
 
 - name: Install oc
   block:
-    - name: Check if oc tarball has been previously downloaded
-      stat:
-        path: "{{ downloads_path }}/{{ openshift_full_version }}/{{ oc_tar }}"
-      register: downloaded_oc_tar
-
-    - name: Download oc tarball
-      get_url:
-        url: "{{ release_url }}/{{ openshift_full_version }}/{{ oc_tar }}"
-        dest: "{{ downloads_path }}/{{ openshift_full_version }}/"
-        force: "{{ force }}"
-        mode: 0664
-      when:
-        - not downloaded_oc_tar.stat.exists
-
     - name: Check if oc binary has been extracted
       stat:
         path: "{{ downloads_path }}/{{ openshift_full_version }}/oc"
@@ -93,12 +128,13 @@
   block:
     - name: Check if opm tarball has been previously downloaded
       stat:
-        path: "{{ downloads_path }}/{{ openshift_full_version }}/{{ opm_tar }}"
+        path: "{{ downloads_path }}/{{ openshift_full_version }}/{{ stable_opm_tar }}"
       register: downloaded_opm_tar
 
+    # opm needs to be downloaded from stable clients
     - name: Download opm tarball
       get_url:
-        url: "{{ release_url }}/{{ openshift_full_version }}/{{ opm_tar }}"
+        url: "{{ stable_release_url }}/{{ stable_opm_tar }}"
         dest: "{{ downloads_path }}/{{ openshift_full_version }}/"
         mode: 0664
       when:
@@ -111,7 +147,7 @@
 
     - name: Extract binary
       unarchive:
-        src: "{{ downloads_path }}/{{ openshift_full_version }}/{{ opm_tar }}"
+        src: "{{ downloads_path }}/{{ openshift_full_version }}/{{ stable_opm_tar }}"
         dest: "{{ downloads_path }}/{{ openshift_full_version }}"
         owner: "{{ file_owner }}"
         group: "{{ file_group }}"


### PR DESCRIPTION
This change started because it was needed to support OCP nightly builds, where `oc` client need to include the version before `.tar.gz`. Else, tests with assisted installer using nightly builds will fail, like in [this example](https://www.distributed-ci.io/jobs/9ae8ead2-2c6b-474b-a588-ed2c6f10cb87/jobStates?sort=date&task=e4753813-aa50-4dca-a107-fe365400e06a) that we have run in Telco CI labs.

The problem is, when having a nightly build, `release_url` is different (e.g. https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/), and the way of interacting with these resources are a bit tricky, so they need to be handled in a different way.

In our dci-openshift-agent, we have already validated in [this change](https://softwarefactory-project.io/r/c/dci-openshift-agent/+/27122) that we can extract all the artifacts (in this case, the release.txt file and the oc binary) from the OCP release image, so release_url would no longer be needed.

Note that, for `opm` client, nightly builds are not currently including it, so this change also modifies it to rely on stable clients from mirror.openshift.com, which is what is being done also in dci-openshift-agent.

So, tldr, the change implies the following:
- Rely on OCP release image instead of the release URL to download the release.txt and the oc binary
- For this, a stable oc binary needs to be downloaded to extract the artifacts from the release image
- Now the release.txt is directly retrieved from the artifact, not from the release URL
- Now oc binary is directly unarchived from the artifact, not from the release URL
- opm client needs to be downloaded from stable release URL