### PR TITLE
Refresh versions and RHCOS images Jan 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 #############################################################################
 ```
 
-This repository contains playbooks for automating the creation of an OpenShift Container Platform cluster on premise using the Developer Preview version of the OpenShift Assisted Installer. The playbooks require only minimal infrastructure configuration and do not require any pre-existing cluster. Virtual and Bare Metal deployments have been tested in restricted network environments where nodes do not have direct access to the Internet.
+This repository contains playbooks for automating the creation of an OpenShift Container Platform cluster on premise using the Developer Preview version of the OpenShift Assisted Installer. The playbooks require only minimal infrastructure configuration, and do not require any pre-existing cluster. Virtual and Bare Metal deployments have been tested in restricted network environments where nodes do not have direct access to the Internet.
 
 These playbooks assume a prior working knowledge of [Ansible](http://www.ansible.com). They are intended to be run from a `bastion` host, running a subscribed installation of Red Hat Enterprise Linux (RHEL) 8.6, inside the target environment. Pre-requisites can be installed manually or automatically, as appropriate.
 
@@ -35,7 +35,7 @@ Crucible targets versions of Python and Ansible that ship with RHEL. At the mome
 - 4.8
 - 4.9
 - 4.10
-
+- 4.11
 
 
 ## Assisted Installer versions Tested
@@ -59,11 +59,11 @@ Requires the following to be installed on the deployment host:
 - [ipmitool](https://github.com/ipmitool/ipmitool) #For PXE deployment
 
 
-**Important Note** The `openshift-clients` package is part of the [Red Hat OpenShift Container Platform Subscription](https://access.redhat.com/downloads/content/290/). The repo [must be activated on the bastion host](https://docs.openshift.com/container-platform/4.10/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli-rpm_cli-developer-commands) before the dependency installation. It is used for the post-installation cluster validation steps.
+**Important Note** The `openshift-clients` package is part of the [Red Hat OpenShift Container Platform Subscription](https://access.redhat.com/downloads/content/290/). The repo [must be activated on the bastion host](https://docs.openshift.com/container-platform/4.12/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli-rpm_cli-developer-commands) before the dependency installation. It is used for the post-installation cluster validation steps.
 
 
 ```bash
-dnf install ansible python3-netaddr skopeo podman openshift-clients ipmitool python3-pyghmi python3-jmespath
+dnf -y install ansible python3-netaddr skopeo podman openshift-clients ipmitool python3-pyghmi python3-jmespath
 ```
 
 There's also some required Ansible modules that can be installed with the following command:
@@ -151,7 +151,7 @@ ansible-playbook -i inventory.yml site.yml -e "@inventory.vault.yml" --ask-vault
 
 ### Privilege Escalation
 
-For simplicity we suggest that passwordless sudo is set up on all machines. If this is not desirable or possible in your environment then there are two options:
+For simplicity, we suggest that passwordless sudo is set up on all machines. If this is not desirable or possible in your environment, then there are two options:
 
 1. Use the same sudo password for all hosts, and use the `-K` flag on `ansible-playbook`. This will cause Ansible to [prompt for the sudo password](https://docs.ansible.com/ansible/2.9/user_guide/become.html#become-command-line-options). The password provided is then used for *all* hosts.
 1. Set the `ansible_become_password` variable for each host that needs a [sudo password](https://docs.ansible.com/ansible/2.9/user_guide/become.html#become-connection-variables). The passwords can be securely stored in an encrypted Ansible vault.
@@ -161,7 +161,7 @@ For simplicity we suggest that passwordless sudo is set up on all machines. If t
 
 Crucible can automatically set up the services required to deploy and run a cluster. Some are required for the Assisted Installer tool to run, and some are needed for the resulting cluster.
 
-- NTP - The NTP service helps to ensure clocks are synchronised across the resulting cluster which is a requirement for the cluster to function.
+- NTP - The NTP service helps to ensure clocks are synchronized across the resulting cluster, which is a requirement for the cluster to function.
 - Container Registry Local Mirror - Provides a local container registry within the target environment. The Crucible playbooks automatically populates the registry with required images for cluster installation. The registry will continue to be used by the resulting cluster.
 - HTTP Store - Used to serve the Assisted Installer discovery ISO and allow it to be used as Virtual Media for nodes to boot from.
 - DNS - Optionally set up DNS records for the required cluster endpoints, and nodes. If not automatically set up then the existing configuration will be validated.
@@ -178,10 +178,10 @@ Note that the exact changes made depend on which playbooks or roles are run, and
 
 ### Cluster
 
-The obvious output from these playbooks is a clean OCP cluster with minimal extra configuration. Each node that has been added to the resulting cluster will have:
+The obvious output from these playbooks is a clean OpenShift Container Platform cluster with minimal extra configuration. Each node that has been added to the resulting cluster will have:
 
-- CoreOS installed and configured
-- The configured SSH public key as an authorised key for `root` to allow debugging
+- Red Hat Enterprise Linux CoreOS installed and configured
+- The configured SSH public key as an authorized key for `root` to allow debugging
 
 
 ### Prerequisite Services

--- a/inventory.yml.sample
+++ b/inventory.yml.sample
@@ -12,8 +12,8 @@ all:
     cluster_name: clustername
     base_dns_domain: example.lab
 
-    # OpenShift version (4.6.16, 4.7.52, 4.8.43, 4.9.40, or 4.10.16)
-    openshift_full_version: 4.10.16
+    # OpenShift version (4.6.16, 4.7.52, 4.8.43, 4.9.45, 4.10.37, or 4.11.24)
+    openshift_full_version: 4.10.37
 
     # Virtual IP addresses used to access the resulting OpenShift cluster
     api_vip: 10.60.0.96 # the IP address to be used for api.clustername.example.lab and api-int.clustername.example.lab

--- a/roles/get_image_hash/defaults/main.yml
+++ b/roles/get_image_hash/defaults/main.yml
@@ -37,19 +37,29 @@ os_images:
     version: 48.84.202109241901-0
   - openshift_version: '4.9'
     cpu_architecture: x86_64
-    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-4.9.40-x86_64-live.x86_64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-live-rootfs.x86_64.img
-    version: 49.84.202206171736-0
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.45/rhcos-4.9.45-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.45/rhcos-live-rootfs.x86_64.img
+    version: 49.84.202208012046-0
   - openshift_version: '4.10'
     cpu_architecture: x86_64
-    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live-rootfs.x86_64.img
-    version: 410.84.202205191234-0
-  - openshift_version: '4.10'
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.37/rhcos-4.10.37-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.37/rhcos-4.10.37-x86_64-live-rootfs.x86_64.img
+    version: 410.84.202210061459-0
+  - openshift_version: '4.11'
+    cpu_architecture: x86_64
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live-rootfs.x86_64.img
+    version: 411.86.202210072320-0
+  - openshift_version: '4.12'
+    cpu_architecture: x86_64
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live-rootfs.x86_64.img
+    version: 412.86.202301061548-0
+  - openshift_version: '4.12'
     cpu_architecture: arm64
-    url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-aarch64-live.aarch64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-aarch64-live-rootfs.aarch64.img
-    version: 410.84.202205191234-0
+    url: https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-aarch64-live.aarch64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-aarch64-live-rootfs.aarch64.img
+    version: 412.86.202301061548
 
 release_images:
   - openshift_version: '4.6'
@@ -66,17 +76,25 @@ release_images:
     version: 4.8.43
   - openshift_version: '4.9'
     cpu_architecture: x86_64
-    url: quay.io/openshift-release-dev/ocp-release:4.9.40-x86_64
-    version: 4.9.40
+    url: quay.io/openshift-release-dev/ocp-release:4.9.45-x86_64
+    version: 4.9.45
   - openshift_version: '4.10'
     cpu_architecture: x86_64
-    url: quay.io/openshift-release-dev/ocp-release:4.10.16-x86_64
-    version: 4.10.16
+    url: quay.io/openshift-release-dev/ocp-release:4.10.37-x86_64
+    version: 4.10.37
     default: true
-  - openshift_version: '4.10'
+  - openshift_version: '4.11'
+    cpu_architecture: x86_64
+    url: quay.io/openshift-release-dev/ocp-release:4.11.24-x86_64
+    version: 4.11.24
+  - openshift_version: '4.12'
+    cpu_architecture: x86_64
+    url: quay.io/openshift-release-dev/ocp-release:4.12.0-x86_64
+    version: 4.12.0
+  - openshift_version: '4.12'
     cpu_architecture: arm64
-    url: quay.io/openshift-release-dev/ocp-release:4.10.16-aarch64
-    version: 4.10.16
+    url: quay.io/openshift-release-dev/ocp-release:4.12.0-aarch64
+    version: 4.12.0
 
 assisted_service_image_repo_url: quay.io/edge-infrastructure
 
@@ -93,4 +111,3 @@ assisted_installer_images:
     url: "{{ assisted_service_image_repo_url }}/assisted-installer-ui:{{ assisted_service_gui_tag }}"
   image_service:
     url: "{{ assisted_service_image_repo_url }}/assisted-image-service:{{ assisted_service_image_service_tag }}"
-  

--- a/roles/validate_inventory/defaults/main.yml
+++ b/roles/validate_inventory/defaults/main.yml
@@ -27,7 +27,8 @@ supported_ocp_versions:
 - 4.6.16
 - 4.7.52
 - 4.8.43
-- 4.9.40
-- 4.10.16
+- 4.9.45
+- 4.10.37
+- 4.11.24
 
 single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"

--- a/tests/validate_inventory/templates/all_reachable.yml
+++ b/tests/validate_inventory/templates/all_reachable.yml
@@ -2,7 +2,7 @@ all:
   vars:
     setup_ntp_service: false
     ntp_server: localhost
-    openshift_full_version: 4.10.16
+    openshift_full_version: 4.10.37
 
   children:
     bastions:

--- a/tests/validate_inventory/templates/all_unreachable.yml
+++ b/tests/validate_inventory/templates/all_unreachable.yml
@@ -2,7 +2,7 @@ all:
   vars:
     setup_ntp_service: false
     ntp_server: 240.0.0.0
-    openshift_full_version: 4.10.16
+    openshift_full_version: 4.10.37
 
   children:
     bastions:

--- a/tests/validate_inventory/templates/invalid_empty_var.yml
+++ b/tests/validate_inventory/templates/invalid_empty_var.yml
@@ -1,6 +1,6 @@
 all:
   vars:
-    openshift_full_version: 4.10.16
+    openshift_full_version: 4.10.37
   children:
     nodes:
       vars:

--- a/tests/validate_inventory/templates/invalid_missing_var.yml
+++ b/tests/validate_inventory/templates/invalid_missing_var.yml
@@ -1,6 +1,6 @@
 all:
   vars:
-    openshift_full_version: 4.10.16
+    openshift_full_version: 4.10.37
   children:
     nodes:
       vars:

--- a/tests/validate_inventory/templates/ntp_unreachable.yml
+++ b/tests/validate_inventory/templates/ntp_unreachable.yml
@@ -2,7 +2,7 @@ all:
   vars:
     setup_ntp_service: false
     ntp_server: 240.0.0.0
-    openshift_full_version: 4.10.16
+    openshift_full_version: 4.10.37
 
   children:
     bastions:

--- a/tests/validate_inventory/templates/test_inv.yml.j2
+++ b/tests/validate_inventory/templates/test_inv.yml.j2
@@ -3,7 +3,7 @@ all:
     {% if item.template.day2_discovery_iso_name is defined %}
     day2_discovery_iso_name: {{ item.template.day2_discovery_iso_name }}
     {% endif %}
-    openshift_full_version: {{ item.template.openshift_full_version | default('4.10.16') }}
+    openshift_full_version: {{ item.template.openshift_full_version | default('4.10.37') }}
     setup_dns_service: {{ item.template.setup_dns_service | default(False)}}
     {% if item.template.allow_custom_vendor is defined %}
     allow_custom_vendor: {{ item.template.allow_custom_vendor }}

--- a/tests/validate_inventory/templates/test_inv_secrets.yml.j2
+++ b/tests/validate_inventory/templates/test_inv_secrets.yml.j2
@@ -1,6 +1,6 @@
 all:
   vars:
-    openshift_full_version: {{ item.template.openshift_full_version | default('4.10.16') }}
+    openshift_full_version: {{ item.template.openshift_full_version | default('4.10.37') }}
   children:
     services:
       hosts:


### PR DESCRIPTION
This PR:

(1) refreshes RHCOS base images used for the 4.9, 4.10, and 4.11 releases to a more recent version hosted on the OpenShift mirror site (mirror.openshift.com).  These represent four months of RHEL fixes and should be used as a base vs their older counterparts.
(2) refreshes supported OpenShift versions to align with respective RHCOS images.  Customers and partners should also try to stay current with enhancements and security fixes present in these newer versions.
(3) update documentation to reflect support for OpenShift 4.12 client tools.  OpenShift 4.12 needs to be tested before support is claimed in validate_inventory and in the README.
(4) validate_inventory tests version numbering is updated.
(5) switches arm from 4.10 to 4.12.