### PR TITLE
Make kubeadmin creds output in nice json

### DIFF
--- a/roles/post_install/tasks/main.yml
+++ b/roles/post_install/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Save credentials to file
   copy:
-    content: "{{ credentials.json | to_yaml }}"
+    content: "{{ credentials.json | to_nice_json }}"
     dest: "{{ dest_dir }}/{{ kubeadmin_vault_name }}"
     mode: 0600
 


### PR DESCRIPTION
This allows for jq to read the creds easily making it easer to work with the kubeadmin vault