### PR TITLE
Update grub location for PXE installs

### DIFF
--- a/roles/insert_dns_records/templates/openshift-cluster.conf.j2
+++ b/roles/insert_dns_records/templates/openshift-cluster.conf.j2
@@ -77,6 +77,6 @@ enable-tftp
 tftp-root={{ TFTP_ROOT }}
 dhcp-vendorclass=BIOS,PXEClient:Arch:00000
 dhcp-boot=tag:BIOS,lpxelinux.0
-dhcp-boot=tag:!BIOS,shimx64.efi
+dhcp-boot=tag:!BIOS,BOOTX64.EFI
 
 {% endif %}

--- a/roles/mount_discovery_iso_for_pxe/defaults/main.yml
+++ b/roles/mount_discovery_iso_for_pxe/defaults/main.yml
@@ -10,8 +10,8 @@ mounted_iso_files:
   - "{{ mount_images_directory }}/efiboot.img"
   - "{{ mount_images_directory }}/pxeboot/vmlinuz"
   - "{{ mount_images_directory }}/pxeboot/initrd.img"
-  - "{{ mount_efiboot_directory }}/EFI/redhat/grubx64.efi"
-  - "{{ mount_efiboot_directory }}/EFI/redhat/shimx64.efi"
+  - "{{ mount_efiboot_directory }}/EFI/BOOT/grubx64.efi"
+  - "{{ mount_efiboot_directory }}/EFI/BOOT/BOOTX64.EFI"
 
 mounted_tftp_files: "http://{{ HTTPD_PXE_HOST }}/{{ pxe_directory }}"
 tftp_files_to_download:
@@ -20,7 +20,7 @@ tftp_files_to_download:
   - "{{ mounted_tftp_files }}/vmlinuz"
   - "{{ mounted_tftp_files }}/initrd.img"
   - "{{ mounted_tftp_files }}/grubx64.efi"
-  - "{{ mounted_tftp_files }}/shimx64.efi"
+  - "{{ mounted_tftp_files }}/BOOTX64.EFI"
 
 system_files_to_download:
   - "{{ mounted_tftp_files }}/lpxelinux.0" 


### PR DESCRIPTION
The Discovery ISO must have changed where the grub entries are found.  This updates to the new paths.