### PR TITLE
Fix support for RHEL 9

### DIFF
--- a/.github/workflows/crucible-tests.yml
+++ b/.github/workflows/crucible-tests.yml
@@ -18,14 +18,14 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.???') }}
 
       - name: Install required dependencies
         run: |
           pip install ansible
           pip install -r requirements.txt
+          ansible-galaxy collection install -r requirements.yml
 
       - name: Run all tests using Ansible
         run: ansible-playbook run_tests.yml
         working-directory: ./tests
-

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,7 @@
 ---
 collections:
   - ansible.posix
+  - ansible.utils
   - containers.podman
   - community.crypto
   - name: community.general

--- a/roles/insert_dns_records/tasks/main.yml
+++ b/roles/insert_dns_records/tasks/main.yml
@@ -27,9 +27,9 @@
         }
       ) }}"
   loop: "{{ groups['nodes'] }}"
-  when: 
+  when:
     - hostvars[item]['bmc_ip'] is defined
-    - hostvars[item]['bmc_ip'] | ipaddr('bool') 
+    - hostvars[item]['bmc_ip'] | ansible.utils.ipaddr('bool')
 
 - name: Define bmc_address where required
   set_fact:
@@ -46,10 +46,10 @@
     entry_address: "{{ hostvars[item]['ansible_fqdn'] }}"
     entry_name: "{{ item }}"
   loop: "{{ groups['bastions'] + groups['services'] }}"
-  when: 
+  when:
     - item != 'registry_host'
-    - hostvars[item][hostvars[item]['host_ip_keyword'] | default(host_ip_keyword)] | ipaddr('bool') 
-    - not (hostvars[item]['dns_skip_record'] | default(False)) | bool 
+    - hostvars[item][hostvars[item]['host_ip_keyword'] | default(host_ip_keyword)] | ansible.utils.ipaddr('bool')
+    - not (hostvars[item]['dns_skip_record'] | default(False)) | bool
 
 - name: Get registry_host when it ansible_host is an IP address
   include_tasks: create_host_entry.yml
@@ -57,9 +57,9 @@
     entry_address: "{{   hostvars['registry_host']['registry_fqdn'] | default(hostvars['registry_host']['ansible_fqdn']) }}"
     entry_name: "registry_host"
     entry_extra_check: "{{ hostvars['registry_host']['registry_fqdn']  is not defined }}"
-  when: 
+  when:
     - "'registry_host' in hostvars"
-    - hostvars['registry_host'][hostvars['registry_host']['host_ip_keyword'] | default(host_ip_keyword)] | ipaddr('bool') 
+    - hostvars['registry_host'][hostvars['registry_host']['host_ip_keyword'] | default(host_ip_keyword)] | ansible.utils.ipaddr('bool')
     - not (hostvars['registry_host']['dns_skip_record'] | default(False)) | bool
 
 - name: Get vm_hosts when ansible_host is an IP address
@@ -69,7 +69,7 @@
     entry_name: "{{ item }}"
     entry_extra_check: "{{ hostvars[item]['sushy_fqdn']  is not defined }}"
   loop: "{{ groups['vm_hosts'] | default([]) }}"
-  when: hostvars[item][hostvars[item]['host_ip_keyword'] | default(host_ip_keyword)] | ipaddr('bool') and (not (hostvars[item]['dns_skip_record'] | default(False))) | bool 
+  when: hostvars[item][hostvars[item]['host_ip_keyword'] | default(host_ip_keyword)] | ansible.utils.ipaddr('bool') and (not (hostvars[item]['dns_skip_record'] | default(False))) | bool
 
 - name: Configure firewall
   become: true

--- a/roles/insert_dns_records/templates/openshift-cluster.conf.j2
+++ b/roles/insert_dns_records/templates/openshift-cluster.conf.j2
@@ -17,7 +17,7 @@ server={{ upstream_dns }}
 
 {% if use_dhcp %}
 dhcp-range= tag:{{ cluster_name }},{{ dhcp_range_first }},{{ dhcp_range_last }}
-dhcp-option= tag:{{ cluster_name }},option:netmask,{{ (gateway + '/' + prefix | string) | ipaddr('netmask') }}
+dhcp-option= tag:{{ cluster_name }},option:netmask,{{ (gateway + '/' + prefix | string) | ansible.utils.ipaddr('netmask') }}
 dhcp-option= tag:{{ cluster_name }},option:router,{{ gateway }}
 dhcp-option= tag:{{ cluster_name }},option:dns-server,{{ listen_address }}
 dhcp-option= tag:{{ cluster_name }},option:domain-search,{{ domain }}

--- a/roles/setup_vm_host_network/defaults/main.yml
+++ b/roles/setup_vm_host_network/defaults/main.yml
@@ -1,5 +1,5 @@
-vm_bridge_ip: "{{ machine_network_cidr | ipaddr('next_usable') }}"
-vm_bridge_prefix: "{{ machine_network_cidr | ipaddr('prefix') }}"
+vm_bridge_ip: "{{ machine_network_cidr | ansible.utils.ipaddr('next_usable') }}"
+vm_bridge_prefix: "{{ machine_network_cidr | ansible.utils.ipaddr('prefix') }}"
 vm_bridge_name: "{{ cluster_name }}-br"
 vm_bridge_port_name: "{{ vm_bridge_interface }}"
 vm_vlan_name: "{{ cluster_name }}.{{ vm_vlan_tag }}"

--- a/roles/validate_dns_records/tasks/main.yml
+++ b/roles/validate_dns_records/tasks/main.yml
@@ -17,5 +17,5 @@
     cmd: "{{ required_binary }} {{ item }} +short"
   register: res
   changed_when: false
-  failed_when: res.stdout | ipaddr == false
+  failed_when: res.stdout | ansible.utils.ipaddr == false
   loop: "{{ required_domains }}"

--- a/roles/validate_inventory/tasks/ai.yml
+++ b/roles/validate_inventory/tasks/ai.yml
@@ -14,7 +14,7 @@
 - name: Assert VIPs are within the machine network
   assert:
     that:
-      - hostvars['assisted_installer'][item] | ipaddr(hostvars['assisted_installer']['machine_network_cidr']) | ipaddr('bool')
+      - hostvars['assisted_installer'][item] | ansible.utils.ipaddr(hostvars['assisted_installer']['machine_network_cidr']) | ansible.utils.ipaddr('bool')
     fail_msg: "{{ item }} is not within the machine network!"
   when: vip_dhcp_allocation == false
   loop:
@@ -24,7 +24,7 @@
 - name: Assert nodes are within the machine network
   assert:
     that:
-      - hostvars[item]['ansible_host'] | ipaddr(hostvars['assisted_installer']['machine_network_cidr']) | ipaddr('bool')
+      - hostvars[item]['ansible_host'] | ansible.utils.ipaddr(hostvars['assisted_installer']['machine_network_cidr']) | ansible.utils.ipaddr('bool')
     fail_msg: "{{ item }} is not within the machine network!"
   when: vip_dhcp_allocation == false
   loop: "{{ groups['masters'] + (groups['workers'] | default([])) }}"  # This should not include day2_workers as they can be RWNs

--- a/roles/validate_inventory/tasks/cluster.yml
+++ b/roles/validate_inventory/tasks/cluster.yml
@@ -49,12 +49,12 @@
 - name: Assert bmc_ip is correct type
   assert:
     that:
-      - hostvars[item]['bmc_ip'] | ipaddr('bool')
+      - hostvars[item]['bmc_ip'] | ansible.utils.ipaddr('bool')
     quiet: true
     fail_msg: "Node {{ item }}'s bmc_ip must be a valid IP address'"
   loop: "{{ groups['nodes'] }}"
   when: hostvars[item]['bmc_ip'] is defined
-  
+
 - name: Assert bmc_address is correct type
   assert:
     that:
@@ -67,7 +67,7 @@
 - name: Assert required vars are correctly typed
   assert:
     that:
-      - (hostvars[item]['mac'] | hwaddr('bool')) == true
+      - (hostvars[item]['mac'] | ansible.utils.hwaddr('bool')) == true
       - hostvars[item]['bmc_password'] is string
       - hostvars[item]['bmc_user'] is string
       - hostvars[item]['vendor'] is string
@@ -81,7 +81,7 @@
       - ( hostvars[item]['mac'] | string | regex_search('^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$')) is not none
     quiet: true
     fail_msg: |-
-      The mac address for node {{ item }} needs to be in linx format XX:XX:XX:XX:XX:XX 
+      The mac address for node {{ item }} needs to be in linx format XX:XX:XX:XX:XX:XX
       Make sure to wrap it quotes to make sure it is not being mangled
       Current value: {{ hostvars[item]['mac'] }}
   loop: "{{ groups['nodes'] }}"

--- a/roles/validate_inventory/tasks/dns.yml
+++ b/roles/validate_inventory/tasks/dns.yml
@@ -3,7 +3,7 @@
   assert:
     that:
       - hostvars['dns_host'][item] is defined
-      - hostvars['dns_host'][item] | ipaddr('bool') == True
+      - hostvars['dns_host'][item] | ansible.utils.ipaddr('bool') == True
     quiet: true
   when: hostvars['dns_host']['use_dhcp'] | default(false)
   loop:
@@ -14,7 +14,7 @@
   assert:
     that:
       - hostvars['dns_host']['ntp_server'] is defined
-      - hostvars['dns_host']['ntp_server'] | ipaddr('bool') == True
+      - hostvars['dns_host']['ntp_server'] | ansible.utils.ipaddr('bool') == True
   when: hostvars['dns_host']['setup_dns_service'] | default(false) and hostvars['dns_host']['use_dhcp'] | default(false)
 
 # All other DNS config is excluded for brevity at this time.

--- a/roles/validate_inventory/tasks/ntp.yml
+++ b/roles/validate_inventory/tasks/ntp.yml
@@ -2,5 +2,5 @@
   assert:
     that:
       - hostvars['ntp_host']['ntp_server'] is defined
-      - hostvars['ntp_host']['ntp_server'] | ipaddr('bool') == True
+      - hostvars['ntp_host']['ntp_server'] | ansible.utils.ipaddr('bool') == True
   when: hostvars['ntp_host']['setup_ntp_service'] | default(false)


### PR DESCRIPTION
The changes requred to support RHEL 9 and ansible-core 2.11 where:
- use full name for ansible.utils.hwaddr
- use full name for ansible.utils.ipaddr
- update requirements.yml adding ansible.utils