### PR TITLE
update 4.12 versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ See [how the playbooks are intended to be run](docs/connecting_to_hosts.md) and 
 
 
 ## Software Versions Supported
-Crucible targets versions of Python and Ansible that ship with RHEL. At the moment the supported versions are:
+Crucible targets versions of Python and Ansible that ship with Red Hat Enterprise Linux. At the moment the supported versions are:
 
-- RHEL 8.6
-- Python 3.6.8
-- Ansible 2.9.27
+| RHEL 8 Based Bastion  | RHEL 9 Based Bastion |
+| --------------------- | -------------------- |
+| RHEL 8.6              | RHEL 9.1             |
+| Python 3.6            | Python 3.9           |
+| Ansible 2.9           | Ansible 2.13         |
 
 
 ## OpenShift Versions Tested
@@ -36,6 +38,7 @@ Crucible targets versions of Python and Ansible that ship with RHEL. At the mome
 - 4.9
 - 4.10
 - 4.11
+- 4.12
 
 
 ## Assisted Installer versions Tested
@@ -45,6 +48,7 @@ Crucible targets versions of Python and Ansible that ship with RHEL. At the mome
 - v2.1.2
 - v2.5.0
 - v2.12.1
+- v2.15.0
 
 ### Dependencies
 

--- a/roles/get_image_hash/defaults/main.yml
+++ b/roles/get_image_hash/defaults/main.yml
@@ -52,14 +52,14 @@ os_images:
     version: 411.86.202210072320-0
   - openshift_version: '4.12'
     cpu_architecture: x86_64
-    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live.x86_64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live-rootfs.x86_64.img
-    version: 412.86.202301061548-0
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live-rootfs.x86_64.img
+    version: 412.86.202302091057-0
   - openshift_version: '4.12'
     cpu_architecture: arm64
-    url: https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-aarch64-live.aarch64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-aarch64-live-rootfs.aarch64.img
-    version: 412.86.202301061548
+    url: https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-aarch64-live.aarch64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-aarch64-live-rootfs.aarch64.img
+    version: 412.86.202302091057-0
 
 release_images:
   - openshift_version: '4.6'
@@ -89,12 +89,12 @@ release_images:
     version: 4.11.24
   - openshift_version: '4.12'
     cpu_architecture: x86_64
-    url: quay.io/openshift-release-dev/ocp-release:4.12.0-x86_64
-    version: 4.12.0
+    url: quay.io/openshift-release-dev/ocp-release:4.12.4-x86_64
+    version: 4.12.4
   - openshift_version: '4.12'
     cpu_architecture: arm64
-    url: quay.io/openshift-release-dev/ocp-release:4.12.0-aarch64
-    version: 4.12.0
+    url: quay.io/openshift-release-dev/ocp-release:4.12.4-aarch64
+    version: 4.12.4
 
 assisted_service_image_repo_url: quay.io/edge-infrastructure
 

--- a/roles/validate_inventory/defaults/main.yml
+++ b/roles/validate_inventory/defaults/main.yml
@@ -30,6 +30,6 @@ supported_ocp_versions:
 - 4.9.45
 - 4.10.37
 - 4.11.24
-- 4.12.0
+- 4.12.4
 
 single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"


### PR DESCRIPTION
This PR:

(1) refreshes RHCOS base images used for the 4.12 release to a more recent version hosted on the OpenShift mirror site (mirror.openshift.com), from version 4.12.0 to version 4.12.3. These represent one month of RHEL fixes and should be used as a base vs their older counterparts.
(2) refreshes supported OpenShift versions for 4.12 to be 4.12.4, which is the latest stable version of 4.12 as of this authoring.  Several fixes in BMO & IPI, the RHEL kernel's iavf driver, etc, went in to address dual stack functionality gaps in 4.12.0 such as https://issues.redhat.com/browse/OCPBUGS-4895, and https://issues.redhat.com/browse/OCPBUGS-6015. Customers and partners should also try to stay current with enhancements and security fixes present in these newer versions of OpenShift Container Platform.
(3) update documentation to reflect support for OpenShift 4.12 and RHEL9 as the bastion host, and tested assisted installer versions.