### PR TITLE
Fix issues with dns validation

### DIFF
--- a/roles/validate_dns_records/defaults/main.yml
+++ b/roles/validate_dns_records/defaults/main.yml
@@ -1,7 +1,13 @@
 required_domains:
-  - "{{ 'api.' + domain }}"
-  - "{{ 'api-int.' + domain }}"
-  - "{{ '*.apps.' + domain }}"
+  "api": "api.{{ domain }}"
+  "api-int": "api-int.{{ domain }}"
+  "apps": "*.apps.{{ domain }}"
+
+expected_answers:
+  "api": "{{ api_vip }}"
+  "api-int": "{{ api_vip }}"
+  "apps": "{{ ingress_vip }}"
+
 required_binary: dig
 required_binary_provided_in_package: bind-utils
 domain: "{{ cluster_name }}.{{ base_dns_domain }}"

--- a/roles/validate_dns_records/tasks/check.yml
+++ b/roles/validate_dns_records/tasks/check.yml
@@ -1,0 +1,16 @@
+- name: Check required domain {item} exists
+  ansible.builtin.shell:
+    cmd: "{{ required_binary }} {{ item.value }} +short"
+  register: res
+  changed_when: false
+
+- name: Check stdout for expected IP address
+  ansible.builtin.set_fact:
+    failed_domains: "{{ (failed_domains | default({})) | combine(
+        {item.value: {
+          'stdout': res.stdout,
+          'stderr': res.stderr,
+          'expected': expected_answers[item.key],
+        }}
+      ) }}"
+  when: expected_answers[item.key] not in res.stdout

--- a/roles/validate_dns_records/tasks/main.yml
+++ b/roles/validate_dns_records/tasks/main.yml
@@ -12,10 +12,25 @@
   become: True
   when: required_binary_check.rc != 0
 
-- name: Check required domain {item} exists
-  ansible.builtin.shell:
-    cmd: "{{ required_binary }} {{ item }} +short"
-  register: res
-  changed_when: false
-  failed_when: res.stdout | ansible.utils.ipaddr == false
-  loop: "{{ required_domains }}"
+- name: Set inital failed_domains
+  ansible.builtin.set_fact:
+    failed_domains: {}
+
+- name: Check domains
+  ansible.builtin.include_tasks: "check.yml"
+  loop: "{{ required_domains | dict2items() }}"
+
+- name: List failed_domains
+  ansible.builtin.fail:
+    msg: |
+      Failed domains:
+        {% for failed in (failed_domains | dict2items) %}
+        {{ failed.key }}:
+            expected:
+              {{ failed.value.expected | indent(14) }}
+            stdout:
+              {{ failed.value.stdout | indent(14)}}
+            stderr:
+              {{ failed.value.stderr | indent(14) }}
+        {% endfor %}
+  when: failed_domains | length > 0


### PR DESCRIPTION
With some record configurations dig will return more than one line which broke the previous approch. Is stead we now check for an expected value being present in the returned string.