### PR TITLE
Default the qemu_user to ansible user

### DIFF
--- a/roles/create_vms/defaults/main.yml
+++ b/roles/create_vms/defaults/main.yml
@@ -1,6 +1,7 @@
 network_name: "net-{{ cluster_name }}"
 path_base_dir: /home/redhat
 vm_create_scripts_dir: "{{ path_base_dir }}/vm_create_scripts/"
+qemu_user: "{{ ansible_user | default(ansible_env.USER) }}"
 
 virt_packages:
   - python3

--- a/roles/create_vms/tasks/main.yml
+++ b/roles/create_vms/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Set qemu user
-  set_fact: 
-    qemu_user: "{{ ansible_user | default(ansible_env.USER) }}"
-
 - name: Setup host environment
   become: true
   block:


### PR DESCRIPTION
We have found in our particular use case we don't want to login as the root user on the target VM Host but we also don't want the VMs to be created as some non-root user. This way we can set `ansible_user` to our non-root user and set `qemu_user` as root. The default (current) behavior stays the same.