### PR TITLE
populate_mirror_registry | Use a tmp folder for oc/kubectl/opm binaries

### DIFF
--- a/roles/populate_mirror_registry/tasks/cleanup.yml
+++ b/roles/populate_mirror_registry/tasks/cleanup.yml
@@ -1,0 +1,7 @@
+---
+# As "opm" is no longer used, let's remove the tmp directory with the binaries.
+# "oc" and "kubectl" will remain in /usr/local/bin
+- name: Remove tmp directory for all binaries
+  file:
+    path: "{{ binaries_tool_path }}"
+    state: absent

--- a/roles/populate_mirror_registry/tasks/main.yml
+++ b/roles/populate_mirror_registry/tasks/main.yml
@@ -11,3 +11,7 @@
 - import_tasks: populate_registry.yml
   tags:
     - populate_registry
+
+- import_tasks: cleanup.yml
+  tags:
+    - populate_registry

--- a/roles/populate_mirror_registry/tasks/populate_registry.yml
+++ b/roles/populate_mirror_registry/tasks/populate_registry.yml
@@ -27,7 +27,7 @@
     - name: Mirror remote ocpmetal image registry to local
       command:
         cmd: >
-          /usr/local/bin/oc image mirror
+          "{{ binaries_tool_path }}"/oc image mirror
             -a "{{ config_file_path }}/{{ pull_secret_file_name }}"
             {{ item.remote }}
             {{ item.local }}:{{ item.local_tag }}
@@ -36,7 +36,7 @@
     - name: Mirror release image to local (x86_64)
       command:
         cmd: >
-          /usr/local/bin/oc adm release mirror 
+          "{{ binaries_tool_path }}"/oc adm release mirror
             -a "{{ config_file_path }}/{{ pull_secret_file_name }}"
             --from="{{ release_image_item.remote | quote }}"
             --to-release-image="{{ release_image_item.local | quote }}:{{ release_image_item.local_tag | quote }}"
@@ -45,7 +45,7 @@
     - name: Mirror release image to local (arm64)
       command:
         cmd: >
-          /usr/local/bin/oc adm release mirror
+          "{{ binaries_tool_path }}"/oc adm release mirror
             -a "{{ config_file_path }}/{{ pull_secret_file_name }}"
             --from="{{ release_image_item_arm.remote | quote }}"
             --to-release-image="{{ release_image_item_arm.local | quote }}:{{ release_image_item_arm.local_tag | quote }}"
@@ -62,7 +62,7 @@
     - name: Build pruned OLM index
       command:
         cmd: >
-          /usr/local/bin/opm index prune 
+          "{{ binaries_tool_path }}"/opm index prune 
             --from-index "{{ olm_index_item.remote }}"
             --packages "{{ mirror_packages | join(',') }}"
             --tag "{{ olm_index_item.local }}:{{ olm_index_item.local_tag }}"
@@ -80,7 +80,7 @@
     - name: Mirror Catalog to local registry 
       command:
         cmd: >
-          oc adm catalog mirror 
+          "{{ binaries_tool_path }}"/oc adm catalog mirror 
             {{ olm_index_item.local }}:{{ olm_index_item.local_tag }}
             {{ olm_item.local }}:{{ olm_item.local_tag }}
             --registry-config="{{ config_file_path }}/{{ pull_secret_file_name }}"

--- a/roles/populate_mirror_registry/tasks/prerequisites.yml
+++ b/roles/populate_mirror_registry/tasks/prerequisites.yml
@@ -82,6 +82,16 @@
         release_version: "{{ result.content | b64decode | regex_search('Version:.*') | regex_replace('Version:\\s*(.*)', '\\1') }}"
         release_image: "{{ result.content | b64decode | regex_search('Pull From:.*') | regex_replace('Pull From:\\s*(.*)', '\\1') }}"
 
+- name: Create tmp directory for all binaries
+  tempfile:
+    state: directory
+    prefix: binaries.
+  register: binaries_tmp_dir
+
+- name: Set binaries_tool_path based on the tmp directory path
+  set_fact:
+    binaries_tool_path: "{{ binaries_tmp_dir.path }}"
+
 - name: Install oc
   block:
     - name: Check if oc binary has been extracted
@@ -100,6 +110,27 @@
       when:
         - not extracted_oc.stat.exists
 
+    - name: Copy binary to binaries_tool_path
+      copy:
+        src: "{{ downloads_path }}/{{ openshift_full_version }}/{{ item }}"
+        dest: "{{ binaries_tool_path }}/{{ item }}"
+        owner: "{{ file_owner }}"
+        group: "{{ file_group }}"
+        mode: 0775
+        remote_src: yes
+      become: true
+      with_items:
+        - kubectl
+        - oc
+
+    - name: Check binary installed
+      command: 
+        cmd: "{{ binaries_tool_path }}/{{ item }} help"
+      with_items:
+        - kubectl
+        - oc
+
+    # Also keep the binary in /usr/local/bin, since "oc" is used in other roles.
     - name: Copy binary to /usr/local/bin
       copy:
         src: "{{ downloads_path }}/{{ openshift_full_version }}/{{ item }}"
@@ -156,10 +187,10 @@
       when:
         - not extracted_opm.stat.exists
 
-    - name: Copy opm to /usr/local/bin
+    - name: Copy opm to binaries_tool_path
       copy:
         src: "{{ downloads_path }}/{{ openshift_full_version }}/opm"
-        dest: /usr/local/bin/opm
+        dest: "{{ binaries_tool_path }}/opm"
         owner: "{{ file_owner }}"
         group: "{{ file_group }}"
         mode: 0775
@@ -168,7 +199,7 @@
 
     - name: Check opm installed
       command:  
-        cmd: /usr/local/bin/opm version
+        cmd: "{{ binaries_tool_path }}/opm" version
   tags:
     - create_registry
     - fetch_opm

--- a/roles/populate_mirror_registry/tasks/prerequisites.yml
+++ b/roles/populate_mirror_registry/tasks/prerequisites.yml
@@ -199,7 +199,7 @@
 
     - name: Check opm installed
       command:  
-        cmd: "{{ binaries_tool_path }}/opm" version
+        cmd: "{{ binaries_tool_path }}/opm version"
   tags:
     - create_registry
     - fetch_opm


### PR DESCRIPTION
- Right now, we are placing all the binaries in `/usr/local/bin`
- It may happen that, if we are sharing the jumphost between multiple OCP clusters, this file path is common for all the deployments.
- It is better to have a dedicated folder for each deployment to save the binaries and use them whenever they are needed.
- Doing this in the populate_mirror_registry.
- Apart from this, we keep the `oc` and `kubectl` binaries in `/usr/local/bin` directories, since they are used in other roles. It is not the case of `opm` binary.