### PR TITLE
Http store quay

### DIFF
--- a/roles/setup_http_store/defaults/main.yml
+++ b/roles/setup_http_store/defaults/main.yml
@@ -4,6 +4,6 @@ http_dir: /opt/http_store
 http_data_dir: "{{ http_dir }}/data"
 http_port: 80
 # Note if you change this you might have to change the env vars and volumes for podman task
-container_image: registry.centos.org/centos/httpd-24-centos7:latest
+container_image: quay.io/centos7/httpd-24-centos7:latest
 file_owner: "{{ ansible_env.USER }}"
 file_group: "{{ file_owner }}"


### PR DESCRIPTION
Sets the HTTP store container_image variable to
"quay.io/centos7/http-24-centos7:latest" since the current registry for
"registry.centos.org/centos/http-24-centos7:latest" was decommisioned on
June 7th, 2023. See [1].
    
[1] https://github.com/CentOS/container-index