### PR TITLE
Add 4.12.4 to the OpenShift version in inventory sample

### DIFF
--- a/inventory.yml.sample
+++ b/inventory.yml.sample
@@ -12,7 +12,7 @@ all:
     cluster_name: clustername
     base_dns_domain: example.lab
 
-    # OpenShift version (4.6.16, 4.7.52, 4.8.43, 4.9.45, 4.10.37, or 4.11.24)
+    # OpenShift version (4.6.16, 4.7.52, 4.8.43, 4.9.45, 4.10.37, 4.11.24, or 4.12.4)
     openshift_full_version: 4.10.37
 
     # Virtual IP addresses used to access the resulting OpenShift cluster


### PR DESCRIPTION
I added the ocp 4.12.4 to the inventory sample because its in [supported_ocp_versions](https://github.com/redhat-partner-solutions/crucible/blob/main/roles/validate_inventory/defaults/main.yml)