### PR TITLE
Dependency on validate_inventory prevents importing the setup_sushy_tools role from external project

### DIFF
--- a/roles/setup_sushy_tools/templates/sushy-emulator.conf.j2
+++ b/roles/setup_sushy_tools/templates/sushy-emulator.conf.j2
@@ -43,7 +43,7 @@ SUSHY_EMULATOR_LIBVIRT_URI = u'qemu:///system'
 # Instruct the libvirt driver to ignore any instructions to
 # set the boot device. Allowing the UEFI firmware to instead
 # rely on the EFI Boot Manager
-SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = False
+SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = True
 
 # The map of firmware loaders dependant on the boot mode and
 # system architecture


### PR DESCRIPTION
Every role in this project sets a dependency on validate_inventory.

This is preventing us from importing the setup_sushy_tools role (or to be more precise, the setup_selfsigned_cert role) from the dci-openshift-agent project.

Please, consider removing this dependency in the setup_selfsigned_cert role.

Test-Hints: assisted-abi