### PR TITLE
Gather more Assisted logs

### DIFF
--- a/roles/generate_manifests/defaults/main.yml
+++ b/roles/generate_manifests/defaults/main.yml
@@ -16,3 +16,5 @@ single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | defau
 manifests: true
 extra_manifests: []
 manifest_templates: "{{ extra_manifests }}"
+
+fetched_dest: "{{ repo_root_path }}/fetched"

--- a/roles/generate_manifests/tasks/main.yml
+++ b/roles/generate_manifests/tasks/main.yml
@@ -38,6 +38,17 @@
     - agent-config.yaml.j2
     - install-config.yaml.j2
 
+# The agent-config files are eventually deleted after its usage, just
+# save them in a safe place in case of needing to check them
+- name: Save a backup of agent-config files
+  fetch:
+    src: "{{ manifests_dir }}/{{ item }}"
+    dest: "{{ fetched_dest }}/{{ item }}"
+    flat: true
+  loop:
+    - agent-config.yaml
+    - install-config.yaml
+
 - name: Create extra_manifest_dir dir
   ansible.builtin.file:
     name: "{{ extra_manifest_dir }}"

--- a/roles/monitor_agent_based_installer/defaults/main.yml
+++ b/roles/monitor_agent_based_installer/defaults/main.yml
@@ -1,2 +1,5 @@
 generated_dir: "{{ repo_root_path }}/generated"
 manifests_dir: "{{ generated_dir}}/{{ cluster_name }}"
+
+agent_based_installer_bootstrap_node: "{{ groups['masters'][0] }}"
+host_ip_keyword: ansible_host

--- a/roles/monitor_agent_based_installer/tasks/main.yml
+++ b/roles/monitor_agent_based_installer/tasks/main.yml
@@ -4,7 +4,29 @@
     chdir: "{{ manifests_dir }}"
   ignore_errors: True # Timeout is fixed and some bare metal clusters complete bootstrap just after the timeout
 
-- name: Wait for install complete
-  ansible.builtin.shell:
-    cmd: "{{ agent_based_installer_path }} --log-level=debug agent wait-for install-complete"
-    chdir: "{{ manifests_dir }}"
+- name: Check installation and gather jobs if it fails
+  block:
+    - name: Wait for install complete
+      ansible.builtin.shell:
+        cmd: "{{ agent_based_installer_path }} --log-level=debug agent wait-for install-complete"
+        chdir: "{{ manifests_dir }}"
+
+  rescue:
+    # Using master-0 IP address to reach the bootstrap VM
+    # Placing the logs in repo_root_path
+    # Trying several times in case there are SSH connectivity issues
+    - name: Gather logs from installation
+      vars:
+        rendezvous_ip_address: "{{ hostvars[agent_based_installer_bootstrap_node][host_ip_keyword] }}"
+      ansible.builtin.shell:
+        cmd: "{{ agent_based_installer_path }} --log-level=debug gather bootstrap --bootstrap {{ rendezvous_ip_address }}"
+        chdir: "{{ repo_root_path }}"
+      register: command_result
+      until: command_result.rc == 0
+      retries: 6
+      delay: 20
+      ignore_errors: True
+
+    - name: Fail properly because installation was not completed
+      fail:
+        msg: "Installation was not completed"


### PR DESCRIPTION
- If installation fails, try to run `openshift-install gather bootstrap` command to retrieve logs from the bootstrap node (master-0)
- Backup agent-config files