### PR TITLE
Add support to NATted networks

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -382,7 +382,7 @@ If you need VMs with static UUIDs to allow them to be reused then the UUID for a
 
 #### Bridged network vs. NATted network
 
-By default, this repository deploys a bridged network to interconnect all virtual machines created between them, but it is possible to use a NATted network instead. You just need to set `use_natted_network` to `true` (default `false`) and `use_bridged_network` to `false`(default `true`).
+By default, this repository deploys a bridged network to interconnect all virtual machines created between them, but it is possible to use a NATted network instead. To select one option or another, you need to set up `vm_network_mode` to `bridge` (default) or `nat`, respectively.
 
 ### SSH Key Gen
 

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -380,6 +380,9 @@ If you need VMs with static UUIDs to allow them to be reused then the UUID for a
               uuid: d36ebda0-25bf-55ef-9c69-66ad5ef0d39d
 ```
 
+#### Bridged network vs. NATted network
+
+By default, this repository deploys a bridged network to interconnect all virtual machines created between them, but it is possible to use a NATted network instead. You just need to set `use_natted_network` to `true` (default `false`) and `use_bridged_network` to `false`(default `true`).
 
 ### SSH Key Gen
 

--- a/roles/create_vms/defaults/main.yml
+++ b/roles/create_vms/defaults/main.yml
@@ -20,3 +20,5 @@ is_on_rhel9: "{{ (ansible_distribution_major_version == '9' and ansible_distribu
 # just activate the proper variable to create one network or another.
 use_bridged_network: true
 use_natted_network: false
+# allowed modes: 'bridge', 'nat', using 'bridge' as default
+vm_network_mode: bridge

--- a/roles/create_vms/defaults/main.yml
+++ b/roles/create_vms/defaults/main.yml
@@ -16,3 +16,7 @@ virt_packages:
 images_dir: /var/lib/libvirt/images/
 
 is_on_rhel9: "{{ (ansible_distribution_major_version == '9' and ansible_distribution == 'RedHat') | bool }}"
+# By default, a bridged network is created, but you can also deploy a NATted network if required,
+# just activate the proper variable to create one network or another.
+use_bridged_network: true
+use_natted_network: false

--- a/roles/create_vms/defaults/main.yml
+++ b/roles/create_vms/defaults/main.yml
@@ -16,9 +16,6 @@ virt_packages:
 images_dir: /var/lib/libvirt/images/
 
 is_on_rhel9: "{{ (ansible_distribution_major_version == '9' and ansible_distribution == 'RedHat') | bool }}"
-# By default, a bridged network is created, but you can also deploy a NATted network if required,
-# just activate the proper variable to create one network or another.
-use_bridged_network: true
-use_natted_network: false
+
 # allowed modes: 'bridge', 'nat', using 'bridge' as default
 vm_network_mode: bridge

--- a/roles/create_vms/tasks/prepare_network.yml
+++ b/roles/create_vms/tasks/prepare_network.yml
@@ -1,6 +1,16 @@
 - name: Setup network
   become: true
   block:
+    - name: Check if the selected network mode is allowed
+      vars:
+        allowed_vm_network_modes:
+          - bridge
+          - nat
+      assert:
+        that:
+          - vm_network_mode in allowed_vm_network_modes
+        fail_msg: "{{ vm_network_mode }} is not a supported network mode"
+
     - name: define network
       community.libvirt.virt_net:
         name: "{{ network_name }}"

--- a/roles/create_vms/tasks/prepare_network.yml
+++ b/roles/create_vms/tasks/prepare_network.yml
@@ -1,16 +1,6 @@
 - name: Setup network
   become: true
   block:
-    - name: Check if the selected network mode is allowed
-      vars:
-        allowed_vm_network_modes:
-          - bridge
-          - nat
-      assert:
-        that:
-          - vm_network_mode in allowed_vm_network_modes
-        fail_msg: "{{ vm_network_mode }} is not a supported network mode"
-
     - name: define network
       community.libvirt.virt_net:
         name: "{{ network_name }}"

--- a/roles/create_vms/templates/network.xml.j2
+++ b/roles/create_vms/templates/network.xml.j2
@@ -1,10 +1,10 @@
 <network>
   <name>{{ network_name }}</name>
   <uuid>{{ net_uuid | default(99999999 | random | to_uuid) }}</uuid>
-{% if use_bridged_network | bool %}
+{% if vm_network_mode == 'bridge' %}
   <forward mode='bridge'/>
   <bridge name='{{ vm_bridge_name }}'/>
-{% elif use_natted_network | bool %}
+{% elif vm_network_mode == 'nat' %}
   <forward mode='nat'/>
   <bridge name='{{ vm_bridge_name }}' stp='on' delay='0'/>
   <ip address="{{ vm_bridge_ip }}" />

--- a/roles/create_vms/templates/network.xml.j2
+++ b/roles/create_vms/templates/network.xml.j2
@@ -1,6 +1,12 @@
 <network>
   <name>{{ network_name }}</name>
   <uuid>{{ net_uuid | default(99999999 | random | to_uuid) }}</uuid>
+{% if use_bridged_network | bool %}
   <forward mode='bridge'/>
   <bridge name='{{ vm_bridge_name }}'/>
+{% elif use_natted_network | bool %}
+  <forward mode='nat'/>
+  <bridge name='{{ vm_bridge_name }}' stp='on' delay='0'/>
+  <ip address="{{ vm_bridge_ip }}" />
+{% endif %}
 </network>

--- a/roles/process_nmstate/templates/nmstate.yml.j2
+++ b/roles/process_nmstate/templates/nmstate.yml.j2
@@ -10,6 +10,9 @@ dns-resolver:
 interfaces:
 {% for interface in network_config.interfaces %}
   - name: {{ interface.name }}
+    {% if interface.mac is defined %}
+    mac: {{ interface.mac }}
+    {% endif %}
     state: {{ interface.state | default('up') }}
     type: {{ interface.type | default('ethernet') }}
     {% if interface.addresses.ipv4 is defined %}

--- a/roles/process_nmstate/templates/nmstate.yml.j2
+++ b/roles/process_nmstate/templates/nmstate.yml.j2
@@ -11,7 +11,7 @@ interfaces:
 {% for interface in network_config.interfaces %}
   - name: {{ interface.name }}
     {% if interface.mac is defined %}
-    mac: {{ interface.mac }}
+    mac-address: {{ interface.mac }}
     {% endif %}
     state: {{ interface.state | default('up') }}
     type: {{ interface.type | default('ethernet') }}

--- a/roles/validate_inventory/defaults/main.yml
+++ b/roles/validate_inventory/defaults/main.yml
@@ -35,3 +35,6 @@ supported_ocp_versions:
   - 4.14.2
 
 single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"
+
+# allowed modes: 'bridge', 'nat', using 'bridge' as default
+vm_network_mode: bridge

--- a/roles/validate_inventory/tasks/vms.yml
+++ b/roles/validate_inventory/tasks/vms.yml
@@ -80,3 +80,13 @@
         that:
           - (kvm_node_uuids | length) == (kvm_node_uuids | unique | length)
         fail_msg: "KVM node UUIDs must be unique otherwise they won't build or will collide during discovery"
+
+- name: Check if the selected network mode is allowed
+  vars:
+    allowed_vm_network_modes:
+      - bridge
+      - nat
+  assert:
+    that:
+      - vm_network_mode in allowed_vm_network_modes
+    fail_msg: "{{ vm_network_mode }} is not a supported network mode"


### PR DESCRIPTION
- Currently, only bridged networks are supported for VMs created by Crucible
- There are partners interested in moving to a NATted network instead
- Adding this feature, using bridged networks by default
- Adding instructions about how to use it
- Adding a missed field in nmstate template related to MAC addresses