### PR TITLE
add extra VIPs support for dualstack on OCP >= 4.12

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -271,7 +271,10 @@ To enable assisted installer to communicate via IPv6 you must first have the hos
 
 #### Dual Stack
 
-Openshift currently only allows the ingress and API VIPs to be single stack so you must choose IPv4 or IPv6. Then crucible offers 3 variables for the extra network configuration (`extra_machine_networks`, `extra_service_networks` and `extra_cluster_networks`):
+Crucible offers 3 variables for the extra network configuration (`extra_machine_networks`, `extra_service_networks` and `extra_cluster_networks`), and for the VIPs there are two main configurations:
+
+- Openshift 4.11 and below only allow the ingress and API VIPs to be single stack so you must choose IPv4 or IPv6.
+- Openshift 4.12 and above allow an IPv4 and IPv6 address, hence you can use 2 extra variables to define them: `extra_api_vip` and `extra_ingress_vip`.
 
 ```yaml
 all:
@@ -292,6 +295,11 @@ all:
     extra_cluster_networks:
       - cidr: fd01::/48
         host_prefix: 64
+
+    # Next two variables only supported on OCP >= 4.12
+    extra_api_vip: fd00:6:6:2051::96
+    extra_ingress_vip: fd00:6:6:2051::97
+
 ...
       children:
         masters:

--- a/roles/generate_manifests/defaults/main.yml
+++ b/roles/generate_manifests/defaults/main.yml
@@ -18,3 +18,6 @@ extra_manifests: []
 manifest_templates: "{{ extra_manifests }}"
 
 fetched_dest: "{{ repo_root_path }}/fetched"
+
+api_vips: "{% if extra_api_vip is defined %}{{ [api_vip] + [extra_api_vip] }}{% else %}{{ [api_vip] }}{% endif %}"
+ingress_vips: "{% if extra_ingress_vip is defined %}{{ [ingress_vip] + [extra_ingress_vip] }}{% else %}{{ [ingress_vip] }}{% endif %}"

--- a/roles/generate_manifests/templates/install-config.yaml.j2
+++ b/roles/generate_manifests/templates/install-config.yaml.j2
@@ -37,9 +37,13 @@ platform:
   {% else %}
   baremetal:
     apiVips:
-      - {{ api_vip }}
+      {% for vip in api_vips %}
+      - {{ vip }}
+      {% endfor %}
     ingressVips:
-      - {{ ingress_vip }}
+      {% for vip in ingress_vips %}
+      - {{ vip }}
+      {% endfor %}
   {% endif %}
 sshKey: {{ ssh_public_key }}
 pullSecret: '{{ pull_secret | to_json }}'

--- a/roles/validate_inventory/tasks/ai.yml
+++ b/roles/validate_inventory/tasks/ai.yml
@@ -28,3 +28,60 @@
     fail_msg: "{{ item }} is not within the machine network!"
   when: vip_dhcp_allocation == false
   loop: "{{ groups['masters'] + (groups['workers'] | default([])) }}"  # This should not include day2_workers as they can be RWNs
+
+- name: Validate extra VIPs for dualstack
+  when:
+    - extra_api_vip is defined
+    - extra_api_vip | length > 0
+    - extra_ingress_vip is defined
+    - extra_ingress_vip | length > 0
+  block:
+    - name: Assert that Openshift version is supported for dualstack VIPs
+      assert:
+        that:
+          - openshift_full_version is version('4.12', '>=')
+        fail_msg: "openshift_full_version  must be >= 4.12. to support dualstack VIPs"
+
+    - name: Assert that extra_machine_networks variable is defined and not empty
+      assert:
+        that:
+          - (extra_machine_networks | length) > 0
+        fail_msg: "extra_machine_networks must be defined and have at least one cidr value in a list to support dualstack VIPs"
+
+    - name: Check if extra api VIP is within the extra machine networks
+      vars:
+        extra_api_vip: "{{ hostvars['assisted_installer']['extra_api_vip'] | default ([]) }}"
+        extra_api_vip_tests: []
+      ansible.builtin.set_fact:
+        extra_api_vip_tests: "{{ extra_api_vip_tests + [extra_api_vip | ansible.utils.ipaddr(item.cidr)] }}"
+      when:
+        - vip_dhcp_allocation == false
+        - extra_machine_networks is defined
+      loop: "{{ hostvars['assisted_installer']['extra_machine_networks'] }}"
+
+    - name: Fail if extra api VIP is NOT within any of the extra machine networks
+      ansible.builtin.assert:
+        that:
+          - extra_api_vip in extra_api_vip_tests
+        fail_msg: "{{ extra_api_vip }} is not within any of the extra machine networks!"
+      when:
+        - extra_api_vip_tests is defined
+
+    - name: Check if extra ingress VIP is within the extra machine networks
+      vars:
+        extra_ingress_vip: "{{ hostvars['assisted_installer']['extra_ingress_vip'] | default ([]) }}"
+        extra_ingress_vip_tests: []
+      ansible.builtin.set_fact:
+        extra_ingress_vip_tests: "{{ extra_ingress_vip_tests + [extra_ingress_vip | ansible.utils.ipaddr(item.cidr)] }}"
+      when:
+        - vip_dhcp_allocation == false
+        - extra_machine_networks is defined
+      loop: "{{ hostvars['assisted_installer']['extra_machine_networks'] }}"
+
+    - name: Fail if extra ingress VIP is NOT within any of the extra machine networks
+      ansible.builtin.assert:
+        that:
+          - extra_ingress_vip in extra_ingress_vip_tests
+        fail_msg: "{{ extra_ingress_vip }} is not within any of the extra machine networks!"
+      when:
+        - extra_ingress_vip_tests is defined


### PR DESCRIPTION
This change allows to pass extra VIPS for dualstack deployments using extra_api_vip and extra_ingress_vip variables.

Fixes: #261 