### PR TITLE
Refresh versions and RHCOS images Sep 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Crucible targets versions of Python and Ansible that ship with Red Hat Enterpris
 
 | RHEL 8 Based Bastion  | RHEL 9 Based Bastion |
 | --------------------- | -------------------- |
-| RHEL 8.6              | RHEL 9.1             |
+| RHEL 8.7              | RHEL 9.1             |
 | Python 3.6            | Python 3.9           |
 | Ansible 2.9           | Ansible 2.13         |
 
+For `bastion` machines hosting Virtual Machine (VM) based OpenShift clusters, Red Hat Enterprise Linux 8 is the only QEMU-KVM host supported at this time.  Deficiencies exist in the sushy-tools library that need to be addressed before support can be validated.
 
 ## OpenShift Versions Tested
 
@@ -39,6 +40,7 @@ Crucible targets versions of Python and Ansible that ship with Red Hat Enterpris
 - 4.10
 - 4.11
 - 4.12
+- 4.13
 
 
 ## Assisted Installer versions Tested

--- a/inventory.yml.sample
+++ b/inventory.yml.sample
@@ -12,7 +12,7 @@ all:
     cluster_name: clustername
     base_dns_domain: example.lab
 
-    # OpenShift version (4.6.16, 4.7.52, 4.8.43, 4.9.45, 4.10.37, 4.11.24, or 4.12.4)
+    # OpenShift version (4.6.16, 4.7.52, 4.8.43, 4.9.45, 4.10.37, 4.11.24, 4.12.31, or 4.13.10)
     openshift_full_version: 4.10.37
 
     # Virtual IP addresses used to access the resulting OpenShift cluster

--- a/roles/get_image_hash/defaults/main.yml
+++ b/roles/get_image_hash/defaults/main.yml
@@ -49,19 +49,24 @@ os_images:
     version: 410.84.202210061459-0
   - openshift_version: '4.11'
     cpu_architecture: x86_64
-    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live.x86_64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live-rootfs.x86_64.img
-    version: 411.86.202210072320-0
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.48/rhcos-4.11.48-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.48/rhcos-4.11.48-x86_64-live-rootfs.x86_64.img
+    version: 411.86.202308170928-0
   - openshift_version: '4.12'
     cpu_architecture: x86_64
-    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live.x86_64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live-rootfs.x86_64.img
-    version: 412.86.202302091057-0
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.30/rhcos-4.12.30-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.30/rhcos-4.12.30-x86_64-live-rootfs.x86_64.img
+    version: 412.86.202308161343-0
+  - openshift_version: '4.13'
+    cpu_architecture: x86_64
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.13/4.13.10/rhcos-4.13.10-x86_64-live.x86_64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.13/4.13.10/rhcos-4.13.10-x86_64-live-rootfs.x86_64.img
+    version: 413.92.202308210212-0
   - openshift_version: '4.12'
     cpu_architecture: arm64
-    url: https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-aarch64-live.aarch64.iso
-    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-aarch64-live-rootfs.aarch64.img
-    version: 412.86.202302091057-0
+    url: https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/4.12/4.12.30/rhcos-4.12.30-aarch64-live.aarch64.iso
+    rootfs_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.12/4.12.30/rhcos-4.12.30-aarch64-live-rootfs.aarch64.img
+    version: 412.86.202308161343-0
 
 release_images:
   - openshift_version: '4.6'
@@ -91,12 +96,16 @@ release_images:
     version: 4.11.24
   - openshift_version: '4.12'
     cpu_architecture: x86_64
-    url: quay.io/openshift-release-dev/ocp-release:4.12.4-x86_64
-    version: 4.12.4
+    url: quay.io/openshift-release-dev/ocp-release:4.12.31-x86_64
+    version: 4.12.31
+  - openshift_version: '4.13'
+    cpu_architecture: x86_64
+    url: quay.io/openshift-release-dev/ocp-release:4.13.10-x86_64
+    version: 4.13.10
   - openshift_version: '4.12'
     cpu_architecture: arm64
-    url: quay.io/openshift-release-dev/ocp-release:4.12.4-aarch64
-    version: 4.12.4
+    url: quay.io/openshift-release-dev/ocp-release:4.12.31-aarch64
+    version: 4.12.31
 
 assisted_service_image_repo_url: quay.io/edge-infrastructure
 

--- a/roles/validate_inventory/defaults/main.yml
+++ b/roles/validate_inventory/defaults/main.yml
@@ -30,6 +30,7 @@ supported_ocp_versions:
 - 4.9.45
 - 4.10.37
 - 4.11.24
-- 4.12.4
+- 4.12.31
+- 4.13.10
 
 single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"


### PR DESCRIPTION
This PR:

(1) makes a  specific note around not supporting RHEL9 based Bastion hosts, given internal testing.
(2) refreshes RHCOS base images used for the 4.11 and 4.12 releases to a more recent version hosted on the OpenShift mirror site (mirror.openshift.com). These represent three+ months of RHEL fixes and should be used as a base vs their older counterparts.
(3) refreshes supported OpenShift versions to align with respective RHCOS images. Customers and partners should also try to stay current with enhancements and security fixes present in these newer versions, vs staying on the same release for a long period of time.
(4) update documentation to reflect support for OpenShift 4.13 client tools. OpenShift 4.13 has been tested by teams to have support claimed in validate_inventory and in the README.
(5) updates version of 4.12 from 4.12.4 to 4.12.31 for the release payload.  for Hub clusters, 4.12.4 contains numerous bugs and isn't a recommended version.

Modifications to this PR welcome by the Reviewers.