### PR TITLE
Removed api-int from the required list of dns records.

### DIFF
--- a/roles/validate_dns_records/defaults/main.yml
+++ b/roles/validate_dns_records/defaults/main.yml
@@ -1,11 +1,9 @@
 required_domains:
   "api": "api.{{ domain }}"
-  "api-int": "api-int.{{ domain }}"
   "apps": "*.apps.{{ domain }}"
 
 expected_answers:
   "api": "{{ api_vip }}"
-  "api-int": "{{ api_vip }}"
   "apps": "{{ ingress_vip }}"
 
 required_binary: dig


### PR DESCRIPTION
@novacain1 pointed this out when creating dns reqords for the pinto test lab. It can be seen in the assisted installer documentation.

https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html/assisted_installer_for_openshift_container_platform/preparing-to-install-with-ai#networking

I've gone back and audited previous versions of OCP to find which versions had this requirement and I can't find one that ever did.
| OCP   | api | *.apps  | api-int |
|-------|-----|---------|---------|
| 4.14  | YES | YES     | NO      |
| 4.13  | YES | YES     | NO      |
| 4.12  | YES | YES     | NO      |
| 4.11  | YES | YES     | NO      |
| 4.10  | YES | YES     | NO      |
| 4.9   | YES | YES     | NO      |
| 4.8   | YES | YES     | NO      |
| 4.7   | NA  | NA      | NA      |
