### PR TITLE
Revert changes to use community.crypto collection in setup_selfsigned_cert

### DIFF
--- a/roles/setup_selfsigned_cert/tasks/main.yml
+++ b/roles/setup_selfsigned_cert/tasks/main.yml
@@ -31,12 +31,11 @@
   become: true
 
 - name: Generate an OpenSSL private key
-  community.crypto.openssl_privatekey:
+  openssl_privatekey:
     path: "{{ privatekey_path }}"
 
-
 - name: Generate an OpenSSL CSR
-  community.crypto.openssl_csr:
+  openssl_csr:
     path: "{{ csr_path }}"
     privatekey_path: "{{ privatekey_path }}"
     common_name: "{{ cert_common_name }}"
@@ -45,24 +44,24 @@
     locality_name: "{{ cert_locality }}"
     organization_name: "{{ cert_organization }}"
     organizational_unit_name: "{{ cert_organizational_unit }}"
-    basic_constraints_critical: true
-    create_subject_key_identifier: true
+    basic_constraints_critical: yes
+    create_subject_key_identifier: yes
     basic_constraints: ["CA:TRUE"]
 
 - name: Generate a selfsigned OpenSSL CA Certificate
-  community.crypto.x509_certificate:
+  openssl_certificate:
     path: "{{ ownca_path }}"
     privatekey_path: "{{ privatekey_path }}"
     csr_path: "{{ csr_path }}"
     provider: selfsigned
 
 - name: Generate an ownca OpenSSL Certificate
-  community.crypto.x509_certificate:
+  openssl_certificate:
     path: "{{ cert_path }}"
     ownca_privatekey_path: "{{ privatekey_path }}"
     csr_path: "{{ csr_path }}"
     ownca_path: "{{ ownca_path }}"
-    ownca_create_authority_key_identifier: true
+    ownca_create_authority_key_identifier: yes
     provider: ownca
 
 - name: Set cert in CA trust


### PR DESCRIPTION
This reverts some of the changes included in https://github.com/redhat-partner-solutions/crucible/commit/c86104c6b1b6070043c4eccb9f18993430412484

While testing Assisted deployments with DCI on a daily basis, e.g. here: https://www.distributed-ci.io/jobs/68c4cb1f-0ff6-4a76-b6f0-4c2704c78214/jobStates?sort=date, we discovered that the usage of community.crypto is affecting the jobs, since it's not available for downloading through RPM. Its usage in DCI would depend on creating a custom RPM and inject it in the project, and that's something we would like to avoid unless it's unavoidable to use community.crypto.

Then, the proposal is to revert the usage of community.crypto in setup_selfsigned_cert. 