### PR TITLE
populate_mirror_registry | Ensure pullsecret is placed in config_file_path

### DIFF
--- a/roles/populate_mirror_registry/tasks/prerequisites.yml
+++ b/roles/populate_mirror_registry/tasks/prerequisites.yml
@@ -17,6 +17,23 @@
     state: present
   become: true
 
+# The pullsecret is copied in config_file_path in setup_mirror_registry, and this copy can
+# be modified in that role. This role is usually executed prior to populate_mirror_registry,
+# so we need to check if the pullsecret is present there or not.
+- name: "Check if {{ pull_secret_file_name }} has already been copied in {{ config_file_path }}"
+  stat:
+    path: "{{ config_file_path }}/{{ pull_secret_file_name }}"
+  register: copied_pull_secret
+
+# If not present, let's copy it for the next tasks that require it.
+- name: Copy pull_secret
+  copy:
+    src: "{{ local_pull_secret_path }}"
+    dest: "{{ config_file_path }}/{{ pull_secret_file_name }}"
+    mode: 0644
+  when:
+    - not copied_pull_secret.stat.exists
+
 - name: Create download dirs
   ansible.builtin.file:
     path: "{{ item }}"


### PR DESCRIPTION
The pullsecret is copied in `config_file_path` in `setup_mirror_registry`, and this copy can be modified in that role. This role is usually executed prior to `populate_mirror_registry`, so we need to check if the pullsecret is present there or not.

We have cases using DCI where we don't execute the `setup_mirror_registry` role, but we run `populate_mirror_registry/prerequisites` to download binaries. For this case, where it may happen that the pullsecret is not placed in `config_file_path`, we have to ensure that.