### PR TITLE
Abi testing rhel9

### DIFF
--- a/roles/generate_agent_iso/tasks/main.yml
+++ b/roles/generate_agent_iso/tasks/main.yml
@@ -1,9 +1,16 @@
 - name: Create podman auth dir
   ansible.builtin.file:
-    path: "{{ config_file_path }}/containers/"
+    path: "{{ generated_dir }}/containers/"
     state: directory
     mode: 0755
     recurse: true
+
+- name: Copy pull_secrets file.
+  ansible.builtin.copy:
+    content: "{{ pull_secret }}"
+    dest: "{{ generated_dir }}/containers/auth.json"
+    mode: "0644"
+    remote_src: true
 
 - name: Generate an ISO and print message if there is a failure
   block:

--- a/roles/generate_manifests/templates/registry-config.j2
+++ b/roles/generate_manifests/templates/registry-config.j2
@@ -1,8 +1,4 @@
-{% if ocp_version_major is version('4.14', '<') %}
 imageContentSources:
-{% else %}
-imageDigestSources:
-{% endif %}
   - source: quay.io/openshift-release-dev/ocp-release
     mirrors:
       - {{ mirror_registry }}/{{ registry_repository }}


### PR DESCRIPTION
- Modified: roles/generate_agent_iso/tasks/main.yml
  - Moved the 'podman auth dir' from `config_file_path` to `generated_dir`.
  - This allows the crucible user to create the required files without elevated permissions.
- Modified: roles/generate_manifests/templates/registry-config.j2
  - Removed some templating that was changing imageContentSources into imageDigesstSources.
 
