### PR TITLE
Update XDG_RUNTIME_DIR path in generate_agent_iso

### DIFF
--- a/roles/generate_agent_iso/defaults/main.yml
+++ b/roles/generate_agent_iso/defaults/main.yml
@@ -2,7 +2,6 @@ generated_dir: "{{ repo_root_path }}/generated"
 manifests_dir: "{{ generated_dir }}/{{ cluster_name }}"
 download_agent_dest_file: "{{ discovery_iso_name }}"
 download_dest_path: "{{ iso_download_dest_path | default('/opt/http_store/data') }}"
-config_file_path: /tmp/wip/config
 arch: x86_64
 version_filter: "[?(openshift_version == '{{ openshift_version }}') && (cpu_architecture == '{{ arch }}')]"
 release_image: "{{ (assisted_installer_release_images | json_query(version_filter))[0].url }}"

--- a/roles/generate_agent_iso/tasks/main.yml
+++ b/roles/generate_agent_iso/tasks/main.yml
@@ -19,7 +19,7 @@
         cmd: "{{ agent_based_installer_path }} --log-level=debug agent create image"
         chdir: "{{ manifests_dir }}"
       environment:
-        XDG_RUNTIME_DIR: "{{ config_file_path }}"
+        XDG_RUNTIME_DIR: "{{ generated_dir }}"
       register: gen_iso
   rescue:
     - name: Print message about nmstate package missing


### PR DESCRIPTION
This was causing DCI's abi tests to fail. See here:
https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/93