### PR TITLE
[DRAFT]: update role setup assisted installer configmap

### DIFF
--- a/roles/setup_assisted_installer/defaults/main.yml
+++ b/roles/setup_assisted_installer/defaults/main.yml
@@ -66,3 +66,6 @@ podman_ipv6_network_gateway: 'fd00::1:8:1'
 
 
 assisted_service_extra_config: {}
+
+insecure_skip_verify: false
+

--- a/roles/setup_assisted_installer/templates/configmap.yml.j2
+++ b/roles/setup_assisted_installer/templates/configmap.yml.j2
@@ -20,6 +20,7 @@ data:
   ENABLE_SINGLE_NODE_DNSMASQ: "true"
   HW_VALIDATOR_REQUIREMENTS: {{ assisted_installer_hardware_validation | to_json | quote}}
   IPV6_SUPPORT: "true"
+  INSECURE_SKIP_VERIFY: {{ insecure_skip_verify }}
   LISTEN_PORT: "8888"
   NTP_DEFAULT_SERVER: ""
   OS_IMAGES: {{ assisted_installer_os_images | to_json | quote }}
@@ -45,3 +46,4 @@ data:
   {% for k, v in assisted_service_extra_config.items() %}
   {{ k }}: {{ v }}
   {% endfor %}
+


### PR DESCRIPTION
This PR proposes to add the local registry and set the access to that registry as insecure as first iteration to the assisted service container when using podman and not ABI in disconnected mode. The issue:

`podman logs -f assisted-installer-service`  prompts an x509 ca unknown authority because the certificate is not present inside the `assisted-installer-service` container

I may be missing details I'm not familiar with crucible code, please take a look.
**Do not merge.** We need to test this.