### PR TITLE
update inventory example with proper naming for port using NMstate

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -188,7 +188,7 @@ network_config:
         mode: active-backup
         options:
           miimon: "1500"
-        slaves:
+        port:
           - ens7f0
           - ens7f1
     # To avoid an interface to up, specify its status as down


### PR DESCRIPTION
This PR:

1. updates an inventory example in the documentation to include proper naming.

https://issues.redhat.com/browse/OPNET-468 contains more background on why we should push customers to use the updated "port" nocmenclature.

https://www.redhat.com/en/blog/update-red-hats-conscious-language-efforts is also background on why this is important.